### PR TITLE
feat(docker): add gRPC support for OdbDesignServer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,7 @@ LABEL org.opencontainers.image.source=https://github.com/nam20485/OdbDesign \
     org.opencontainers.image.documentation=https://github.com/nam20485/OdbDesign?tab=readme-ov-file \
     org.opencontainers.image.title="OdbDesign Server"
 
-EXPOSE 8888
-EXPOSE 50051
+EXPOSE 8888 50051
 
 # install dependencies (7z command)
 RUN apt-get update && \

--- a/compose.yml
+++ b/compose.yml
@@ -9,6 +9,7 @@ services:
       - ./compose-designs:/OdbDesign/designs
     ports:
       - 8888:8888
+      - 50051:50051
     environment:
       - ODBDESIGN_SERVER_REQUEST_USERNAME
       - ODBDESIGN_SERVER_REQUEST_PASSWORD
@@ -22,6 +23,7 @@ services:
   #     - ./compose-designs:/OdbDesign/designs
   #   ports:
   #     - 8888:8888
+  #     - 50051:50051
   #   environment:
   #     - ODBDESIGN_SERVER_REQUEST_USERNAME
   #     - ODBDESIGN_SERVER_REQUEST_PASSWORD   

--- a/deploy/kube/OdbDesignServer/deployment.yaml
+++ b/deploy/kube/OdbDesignServer/deployment.yaml
@@ -40,6 +40,9 @@ spec:
           ports:
             - containerPort: 8888
               name: ods-dep-port
+            - containerPort: 50051
+              name: ods-grpc-port
+              protocol: TCP
           volumeMounts:
             - mountPath: /OdbDesign/designs
               name: odbdesign-server-storage

--- a/deploy/kube/OdbDesignServer/service-grpc.yaml
+++ b/deploy/kube/OdbDesignServer/service-grpc.yaml
@@ -1,0 +1,20 @@
+##################################################################################################
+# OdbDesignServer gRPC service (k3d ServiceLB / klipper-lb)
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: odbdesign-server-grpc-service
+  labels:
+    app: odbdesign-server
+    service: odbdesign-server-grpc
+spec:
+  type: LoadBalancer
+  ports:
+    - name: ods-grpc-port
+      port: 50051
+      targetPort: ods-grpc-port
+      protocol: TCP
+  selector:
+    app: odbdesign-server
+

--- a/scripts/create-k3d-cluster.ps1
+++ b/scripts/create-k3d-cluster.ps1
@@ -8,6 +8,9 @@ param(
     # Ingress host port
     [Parameter(Mandatory=$true)]
     [int]$IngressHostPort = 8081,
+    # gRPC host port (LAN access to OdbDesignServer gRPC)
+    [Parameter(Mandatory=$false)]
+    [int]$GrpcHostPort = 50051,
     # When set to true, the cluster will be deleted first
     [switch]$DeleteClusterFirst = $false,
     # When set to true, the cluster will be deleted without asking for confirmation
@@ -27,6 +30,7 @@ $hostIp = "192.168.1.30"
 # $hostIp = "192.168.1.101"
 $ingressHostName = "precision5820"
 $firewallRuleDisplayName = "k3d $ClusterName ingress $IngressHostPort"
+$grpcFirewallRuleDisplayName = "k3d $ClusterName grpc $GrpcHostPort"
 
 function Ensure-IngressFirewallRule {
     param(
@@ -80,12 +84,14 @@ k3d cluster create $ClusterName `
     --k3s-arg="--tls-san=${ingressHostName}@server:0" `
     --port "${IngressHostPort}:80@loadbalancer" `
     --port "8443:443@loadbalancer" `
+    --port "${GrpcHostPort}:50051@loadbalancer" `
     --volume ${HostVolumePath}:/k3dvolume@all
     # --volume ${HostVolumePath}:/tmp/k3dvolume@all
 
 Write-Host "Cluster '$ClusterName' created."
 
 Ensure-IngressFirewallRule -DisplayName $firewallRuleDisplayName -Port $IngressHostPort
+Ensure-IngressFirewallRule -DisplayName $grpcFirewallRuleDisplayName -Port $GrpcHostPort
 
 if ($StartWithWindows) {
     $registerScriptPath = Join-Path $PSScriptRoot "register-k3d-startup-task.ps1"

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -31,6 +31,7 @@ kubectl apply -f deploy/kube/k3d-volume-pvc.yaml
 # apply deployment/service manifests
 kubectl apply -f deploy/kube/OdbDesignServer/deployment.yaml
 kubectl apply -f deploy/kube/OdbDesignServer/service.yaml
+kubectl apply -f deploy/kube/OdbDesignServer/service-grpc.yaml
 
 # restart deployment
 kubectl rollout restart deployment/$DeploymentName


### PR DESCRIPTION
- Updated compose.yml to expose gRPC port 50051.
- Modified Dockerfile to expose both HTTP (8888) and gRPC (50051) ports.
- Enhanced deployment.yaml to include gRPC container port configuration.
- Created new service-grpc.yaml for gRPC service definition.
- Updated create-k3d-cluster.ps1 to include gRPC host port parameter.
- Modified deploy.ps1 to apply the new gRPC service manifest.