### PR TITLE
feat(docker): move GITHUB_TOKEN from build args to BuildKit secrets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,5 @@ build/
 .idea/
 Testing/
 *.code-workspace
+.env
+.env.local

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# =============================================================================
+# OdbDesign compose environment template.
+#   cp .env.example .env   then fill in real values.
+# .env is git-ignored and docker-ignored (never committed, never baked into the
+# image). docker compose auto-loads it from the project directory.
+#
+# NOTE: GITHUB_TOKEN and NUGET_AUTH_TOKEN are typically already exported by your
+# shell (~/.api-keys-export.sh, sourced from ~/.bashrc). You only need to set
+# them here if compose can't see them in the environment (e.g. non-interactive
+# contexts). The build reads them as BuildKit SECRETS, never as build args.
+# =============================================================================
+
+# --- Server runtime credentials (REST :8888 + gRPC :50051 basic auth) ---
+# Currently not defined anywhere by default — set them here or the server starts
+# with empty auth credentials.
+ODBDESIGN_SERVER_REQUEST_USERNAME=
+ODBDESIGN_SERVER_REQUEST_PASSWORD=
+
+# --- Build-time token sources (consumed as BuildKit secrets) ---
+# GitHub PAT. read:packages is enough for local (USE_VCPKG_CACHE=1);
+# write:packages is required if you set USE_VCPKG_CACHE=0 (cache upload).
+GITHUB_TOKEN=
+# GitHub PAT with read:packages scope. REQUIRED for the local read-only vcpkg
+# binary cache (USE_VCPKG_CACHE=1). Same token used by
+# scripts/setup-vcpkg-cache.sh on the host.
+NUGET_AUTH_TOKEN=
+
+# --- Optional build overrides (compose.local.yml already sets sane defaults) ---
+# USE_VCPKG_CACHE=1     # 1 = read-only cache (local dev), 0 = write-enabled (CI)
+# VCPKG_BINARY_SOURCES=clear;nugetconfig,/etc/vcpkg/local.nuget.config,read
+# OWNER=nam20485

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -190,8 +190,13 @@ jobs:
           annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
             OWNER=nam20485
-            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
             VCPKG_BINARY_SOURCES=clear;nuget,GitHub,readwrite
+          # GITHUB_TOKEN is passed as a BuildKit secret (mounted at
+          # /run/secrets/github_token) rather than a build arg, so it never
+          # appears in the build log or the image cache. USE_VCPKG_CACHE
+          # defaults to 0 (write-enabled cache upload).
+          secrets: |
+            "github_token=${{ secrets.GITHUB_TOKEN }}"
 
       # Sign the resulting Docker image digest
       # This will only write to the public Rekor transparency log when the Docker

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,8 @@ gpg_keys/
 .github\instructions\codacy.instructions.md
 /new_designs/
 .kimchi/plans/plan-1781877149619.md
+
+# Local environment files (may contain secrets) — copy .env.example to .env
+.env
+.env.local
+.env.*.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,16 @@
 FROM --platform=$BUILDPLATFORM debian@sha256:346fa035ca82052ce8ec3ddb9df460b255507acdeb1dc880a8b6930e778a553c AS build
 
 ARG OWNER=nam20485
-ARG GITHUB_TOKEN="PASSWORD"
 ARG VCPKG_BINARY_SOURCES=""
+# USE_VCPKG_CACHE=1 enables read-only consumption of the GitHub Packages vcpkg
+# binary cache (local dev / consumer builds). USE_VCPKG_CACHE=0 keeps the legacy
+# write-enabled behavior (CI uploads via the in-image NuGet source).
+#
+# Tokens are supplied as BuildKit secrets (see the RUN --mount=type=secret below),
+# NOT as ARGs, so their values never appear in build logs or the layer cache:
+#   id=github_token     GitHub PAT (write:packages)  — used by the USE_VCPKG_CACHE=0 path
+#   id=nuget_auth_token GitHub PAT (read:packages)   — used by the USE_VCPKG_CACHE=1 path
+ARG USE_VCPKG_CACHE=0
 
 # install dependencies
 RUN apt-get update && \
@@ -38,18 +46,33 @@ RUN ./bootstrap-vcpkg.sh
 # set vcpkg to use NuGet for binary caching
 ENV VCPKG_BINARY_SOURCES=${VCPKG_BINARY_SOURCES}
 
-# setup NuGet to use GitHub Packages as a source so vcpkg binary cache can use it
-RUN mono `./vcpkg fetch nuget | tail -n 1` \
-    sources add \
-    -source "https://nuget.pkg.github.com/${OWNER}/index.json" \
-    -storepasswordincleartext \
-    -name "GitHub" \
-    -username ${OWNER} \
-    -password "${GITHUB_TOKEN}"
-
-RUN mono `./vcpkg fetch nuget | tail -n 1` \
-    setapikey "${GITHUB_TOKEN}" \
-    -source "https://nuget.pkg.github.com/${OWNER}/index.json"
+# When USE_VCPKG_CACHE=1 (local dev): generate a read-only nuget config so vcpkg
+# downloads pre-built packages from GitHub Packages without uploading.
+# When USE_VCPKG_CACHE=0 (CI / default): set up the in-image write-enabled NuGet
+# source so vcpkg uploads built binaries to GitHub Packages.
+RUN --mount=type=secret,id=github_token \
+    --mount=type=secret,id=nuget_auth_token \
+    if [ "${USE_VCPKG_CACHE}" = "1" ]; then \
+        if [ ! -s /run/secrets/nuget_auth_token ]; then \
+            echo "ERROR: USE_VCPKG_CACHE=1 requires the 'nuget_auth_token' build secret, but it is missing/empty." >&2; \
+            echo "       Provide NUGET_AUTH_TOKEN (GitHub PAT with read:packages scope) in the build environment." >&2; \
+            exit 1; \
+        fi; \
+        mkdir -p /etc/vcpkg && \
+        printf '<?xml version="1.0" encoding="utf-8"?>\n<configuration>\n    <packageSources>\n        <clear />\n        <add key="GitHubPackages-OdbDesign" value="https://nuget.pkg.github.com/%s/index.json" />\n    </packageSources>\n    <packageSourceCredentials>\n        <GitHubPackages-OdbDesign>\n            <add key="Username" value="%s" />\n            <add key="ClearTextPassword" value="%s" />\n        </GitHubPackages-OdbDesign>\n    </packageSourceCredentials>\n</configuration>\n' "${OWNER}" "${OWNER}" "$(cat /run/secrets/nuget_auth_token)" \
+            > /etc/vcpkg/local.nuget.config; \
+    else \
+        mono `./vcpkg fetch nuget | tail -n 1` \
+            sources add \
+            -source "https://nuget.pkg.github.com/${OWNER}/index.json" \
+            -storepasswordincleartext \
+            -name "GitHub" \
+            -username ${OWNER} \
+            -password "$(cat /run/secrets/github_token)" && \
+        mono `./vcpkg fetch nuget | tail -n 1` \
+            setapikey "$(cat /run/secrets/github_token)" \
+            -source "https://nuget.pkg.github.com/${OWNER}/index.json"; \
+    fi
 
 # pre-install vcpgk packages BEFORE cmake configure
 RUN mkdir -p /src/OdbDesign
@@ -126,7 +149,7 @@ COPY --from=build /src/OdbDesign/OdbDesignServer/templates/* ./templates
 #RUN mkdir ./designs
 
 # run
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/OdbDesign/bin
+ENV LD_LIBRARY_PATH=/OdbDesign/bin
 # ENV ODBDESIGN_SERVER_REQUEST_USERNAME=${ODBDESIGN_SERVER_REQUEST_USERNAME}
 # ENV ODBDESIGN_SERVER_REQUEST_PASSWORD=${ODBDESIGN_SERVER_REQUEST_PASSWORD}
 RUN chmod +x ./bin/OdbDesignServer

--- a/compose.local.yml
+++ b/compose.local.yml
@@ -7,11 +7,23 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      # GITHUB_TOKEN is required by Dockerfile for NuGet/vcpkg binary cache auth.
-      # Pass via shell env: `GITHUB_TOKEN=... docker compose -f compose.local.yml build`
+      # Read-only vcpkg binary cache (consume pre-built packages from GH Packages,
+      # do NOT upload). USE_VCPKG_CACHE=1 makes the Dockerfile generate a
+      # read-only nuget config at /etc/vcpkg/local.nuget.config from the
+      # nuget_auth_token secret; VCPKG_BINARY_SOURCES then points vcpkg at it.
+      # Requires NUGET_AUTH_TOKEN in the shell env / .env (GitHub PAT with
+      # read:packages scope — same token used by scripts/setup-vcpkg-cache.sh).
       args:
-        - GITHUB_TOKEN=${GITHUB_TOKEN:-}
-        - VCPKG_BINARY_SOURCES=${VCPKG_BINARY_SOURCES:-}
+        - USE_VCPKG_CACHE=1
+        - VCPKG_BINARY_SOURCES=clear;nugetconfig,/etc/vcpkg/local.nuget.config,read
+      # Tokens are injected as BuildKit secrets (mounted at /run/secrets), never
+      # as build args, so they never appear in build logs or the image cache.
+      # Resolved from the host environment (or the project .env file):
+      #   github_token     <- GITHUB_TOKEN
+      #   nuget_auth_token <- NUGET_AUTH_TOKEN
+      secrets:
+        - github_token
+        - nuget_auth_token
     volumes:
       - ./compose-designs:/OdbDesign/designs
     # No host-published ports — nginx (the `proxy` service below) is the
@@ -59,3 +71,13 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+
+# Build-time secret sources. Each reads its value from the host environment
+# (or the project .env file) and mounts it into the build container at
+# /run/secrets/<name>. Values never pass through build args, so they are
+# absent from build logs and the layer cache.
+secrets:
+  github_token:
+    environment: GITHUB_TOKEN
+  nuget_auth_token:
+    environment: NUGET_AUTH_TOKEN

--- a/scripts/setup-vcpkg-cache.sh
+++ b/scripts/setup-vcpkg-cache.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+#
+# setup-vcpkg-cache.sh
+# ---------------------
+# Linux/Bash equivalent of scripts/setup-vcpkg-cache.ps1.
+#
+# Configures the local machine to consume the OdbDesign vcpkg binary cache
+# stored in GitHub Packages. After running, set VCPKG_BINARY_SOURCES in your
+# shell (or shell rc) to the value printed at the end of this script.
+#
+# Required env: NUGET_AUTH_TOKEN  (GitHub PAT with read:packages scope)
+#
+# Optional env:
+#   VCPKG_CACHE_USERNAME  (default: nam20485)
+#   VCPKG_CACHE_FEED_URL  (default: https://nuget.pkg.github.com/nam20485/index.json)
+#
+# Usage:
+#   NUGET_AUTH_TOKEN=ghp_xxx ./scripts/setup-vcpkg-cache.sh
+#   NUGET_AUTH_TOKEN=ghp_xxx ./scripts/setup-vcpkg-cache.sh --add-to-bashrc
+#   NUGET_AUTH_TOKEN=ghp_xxx ./scripts/setup-vcpkg-cache.sh --check    # only verify, don't write
+#
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+USERNAME="${VCPKG_CACHE_USERNAME:-nam20485}"
+FEED_URL="${VCPKG_CACHE_FEED_URL:-https://nuget.pkg.github.com/${USERNAME}/index.json}"
+SOURCE_NAME="GitHubPackages-OdbDesign"
+LOCAL_CONFIG="${REPO_ROOT}/local.nuget.config"
+ADD_TO_BASHRC=0
+CHECK_ONLY=0
+
+usage() {
+    sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --add-to-bashrc) ADD_TO_BASHRC=1 ;;
+        --check)         CHECK_ONLY=1 ;;
+        -h|--help)       usage 0 ;;
+        *)               echo "Unknown arg: $arg" >&2; usage 1 ;;
+    esac
+done
+
+c_red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+c_green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+c_yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+c_cyan()   { printf '\033[36m%s\033[0m\n' "$*"; }
+
+echo
+c_cyan "=== vcpkg Binary Cache Setup for OdbDesign (Linux) ==="
+echo
+
+# Verify PAT present
+if [[ -z "${NUGET_AUTH_TOKEN:-}" ]]; then
+    c_red "Error: NUGET_AUTH_TOKEN env var is not set."
+    echo "Create a GitHub PAT with read:packages scope and re-run:" >&2
+    echo "  https://github.com/settings/tokens/new?scopes=read:packages" >&2
+    exit 1
+fi
+
+c_green "Using feed: ${FEED_URL}"
+c_green "Using username: ${USERNAME}"
+echo
+
+# Generate local.nuget.config with embedded credentials.
+# Pattern matches scripts/setup-vcpkg-cache.ps1 exactly so behaviour is portable.
+cat > "${LOCAL_CONFIG}" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear />
+        <add key="${SOURCE_NAME}" value="${FEED_URL}" />
+    </packageSources>
+    <packageSourceCredentials>
+        <${SOURCE_NAME}>
+            <add key="Username" value="${USERNAME}" />
+            <add key="ClearTextPassword" value="${NUGET_AUTH_TOKEN}" />
+        </${SOURCE_NAME}>
+    </packageSourceCredentials>
+</configuration>
+EOF
+chmod 600 "${LOCAL_CONFIG}"
+
+c_green "Wrote ${LOCAL_CONFIG} (mode 600)"
+
+# Compose the VCPKG_BINARY_SOURCES value.
+# ,read at the end enforces read-only access — local builds must never push.
+ENV_VALUE="clear;nugetconfig,${LOCAL_CONFIG},read"
+
+echo
+c_yellow "To use the binary cache, set this env var in your shell:"
+echo
+echo "    export VCPKG_BINARY_SOURCES=\"${ENV_VALUE}\""
+echo
+
+# --check: validate the credentials by hitting the feed index. Useful as a
+# smoke test before kicking off a long build.
+if [[ "${CHECK_ONLY}" -eq 1 ]]; then
+    c_cyan "Running --check: probing ${FEED_URL} ..."
+    http_code="$(curl -sS -o /dev/null -w '%{http_code}' \
+        -u "${USERNAME}:${NUGET_AUTH_TOKEN}" \
+        "${FEED_URL}" || echo "000")"
+    if [[ "${http_code}" =~ ^2 ]]; then
+        c_green "OK (HTTP ${http_code}) — credentials accepted by GitHub Packages."
+        exit 0
+    elif [[ "${http_code}" == "401" ]]; then
+        c_red "FAIL (HTTP 401) — PAT is invalid or lacks read:packages scope."
+        exit 1
+    else
+        c_yellow "WARN (HTTP ${http_code}) — could not confirm; check connectivity."
+        exit 2
+    fi
+fi
+
+if [[ "${ADD_TO_BASHRC}" -eq 1 ]]; then
+    RC="${HOME}/.bashrc"
+    [[ -f "${RC}" ]] || touch "${RC}"
+    # Idempotent: strip any prior VCPKG_BINARY_SOURCES line first.
+    if grep -q '^[[:space:]]*export[[:space:]]\+VCPKG_BINARY_SOURCES=' "${RC}"; then
+        sed -i.bak -E '/^[[:space:]]*export[[:space:]]+VCPKG_BINARY_SOURCES=/d' "${RC}"
+        rm -f "${RC}.bak"
+    fi
+    {
+        echo
+        echo "# vcpkg binary cache (GitHub Packages) — managed by scripts/setup-vcpkg-cache.sh"
+        echo "export VCPKG_BINARY_SOURCES=\"${ENV_VALUE}\""
+    } >> "${RC}"
+    c_green "Added export to ${RC} (existing value overwritten if any)."
+fi
+
+echo
+c_green "=== Setup complete ==="
+echo
+c_cyan "Local builds (and docker compose -f compose.local.yml) will now consume"
+c_cyan "pre-built packages from GitHub Packages instead of building from source."
+echo


### PR DESCRIPTION
## Summary

Moves Docker build tokens out of `ARG`s (visible in build logs and the image layer cache) into **BuildKit secret mounts**, and adds a read-only vcpkg binary cache mode for local development.

> **Provenance:** these changes originated in a browser-based VS Code session and were stored as VS Code cloud changes (never committed). They were synced to the local working tree on 2026-08-01 and archived to this branch for review.

## Changes

| File | What |
|---|---|
| `Dockerfile` | Removes `ARG GITHUB_TOKEN`; adds `USE_VCPKG_CACHE` flag; tokens supplied via `RUN --mount=type=secret` (`github_token` for CI write path, `nuget_auth_token` for local read-only path). Fixes redundant `LD_LIBRARY_PATH` prefix. |
| `.github/workflows/docker-publish.yml` | Replaces `GITHUB_TOKEN` build-arg with a `secrets:` block so the token never appears in build logs. |
| `compose.local.yml` | Switches to `USE_VCPKG_CACHE=1` + `nugetconfig` read-only source; declares `github_token`/`nuget_auth_token` as compose secrets sourced from env vars. |
| `.gitignore` / `.dockerignore` | Excludes `.env`, `.env.local`, `.env.*.local` so secrets files are never committed or baked into images. |
| `.env.example` *(new)* | Documented template for compose env vars (runtime creds + build-time tokens). |
| `scripts/setup-vcpkg-cache.sh` *(new)* | Bash port of the existing `setup-vcpkg-cache.ps1` — configures local vcpkg binary cache auth with `--check` and `--add-to-bashrc` modes. |

## Security rationale

`ARG GITHUB_TOKEN` values are embedded in the image metadata and visible via `docker history` / build logs. BuildKit secrets (`--mount=type=secret`) are only available during the specific `RUN` step and are never persisted to the layer cache or image metadata.

## Testing notes

- CI path (`USE_VCPKG_CACHE=0`, default): unchanged behavior — write-enabled NuGet source, now reading the token from `/run/secrets/github_token` instead of an ARG.
- Local dev path (`USE_VCPKG_CACHE=1`): generates a read-only `nugetconfig` at `/etc/vcpkg/local.nuget.config`; `,read` suffix prevents accidental cache uploads.
- `scripts/setup-vcpkg-cache.sh --check` can validate credentials before kicking off a build.