### PR TITLE
feat(grpc): add GetStandardFonts endpoint for ODB++ font data

### DIFF
--- a/OdbDesignServer/Services/OdbDesignServiceImpl.cpp
+++ b/OdbDesignServer/Services/OdbDesignServiceImpl.cpp
@@ -606,8 +606,12 @@ namespace OdbDesignServer
                     return {grpc::StatusCode::NOT_FOUND, "Design not found: " + request->design_name()};
                 }
 
-                const auto &fontsFile = fileArchive->GetStandardFontsFile();
-                *response = *fontsFile.to_protobuf();
+                auto fontsFilePb = fileArchive->GetStandardFontsFile().to_protobuf();
+                if (fontsFilePb == nullptr)
+                {
+                    return {grpc::StatusCode::INTERNAL, "Failed to serialize standard fonts file"};
+                }
+                response->CopyFrom(*fontsFilePb);
 
                 loginfo("[ConnTrace] GetStandardFonts done: design_name=\"" + request->design_name() +
                     "\" characters=" + std::to_string(response->m_characterblocks_size()));

--- a/OdbDesignServer/Services/OdbDesignServiceImpl.cpp
+++ b/OdbDesignServer/Services/OdbDesignServiceImpl.cpp
@@ -14,6 +14,7 @@
 #include <cctype>
 #include <App/DesignCache.h>
 #include <design.pb.h>
+#include <standardfontsfile.pb.h>
 #include <vector>
 #include <Logger.h>
 
@@ -587,6 +588,36 @@ namespace OdbDesignServer
             {
                 std::string error = "Internal server error: " + std::string(e.what());
                 return { grpc::StatusCode::INTERNAL, error };
+            }
+        }
+
+        grpc::Status OdbDesignServiceImpl::GetStandardFonts(
+            grpc::ServerContext *context,
+            const Odb::Grpc::GetStandardFontsRequest *request,
+            Odb::Lib::Protobuf::StandardFontsFile *response)
+        {
+            try
+            {
+                loginfo("[ConnTrace] GetStandardFonts start: design_name=\"" + request->design_name() + "\"");
+
+                const auto fileArchive = m_designCache->GetFileArchive(request->design_name());
+                if (fileArchive == nullptr)
+                {
+                    return {grpc::StatusCode::NOT_FOUND, "Design not found: " + request->design_name()};
+                }
+
+                const auto &fontsFile = fileArchive->GetStandardFontsFile();
+                *response = *fontsFile.to_protobuf();
+
+                loginfo("[ConnTrace] GetStandardFonts done: design_name=\"" + request->design_name() +
+                    "\" characters=" + std::to_string(response->m_characterblocks_size()));
+
+                return grpc::Status::OK;
+            }
+            catch (const std::exception &e)
+            {
+                std::string error = "Internal server error: " + std::string(e.what());
+                return {grpc::StatusCode::INTERNAL, error};
             }
         }
 

--- a/OdbDesignServer/Services/OdbDesignServiceImpl.h
+++ b/OdbDesignServer/Services/OdbDesignServiceImpl.h
@@ -8,6 +8,7 @@
 #include <design.pb.h>
 #include <featuresfile.pb.h>
 #include <service.pb.h>
+#include <standardfontsfile.pb.h>
 #include <symbolname.pb.h>
 #include <grpcpp/impl/status.h>
 #include <grpcpp/server_context.h>
@@ -37,6 +38,10 @@ namespace OdbDesignServer {
             grpc::Status GetLayerSymbols(grpc::ServerContext* context,
                 const Odb::Grpc::GetLayerSymbolsRequest* request,
                 Odb::Grpc::GetLayerSymbolsResponse* response) override;
+
+            grpc::Status GetStandardFonts(grpc::ServerContext* context,
+                const Odb::Grpc::GetStandardFontsRequest* request,
+                Odb::Lib::Protobuf::StandardFontsFile* response) override;
 
             grpc::Status HealthCheck(grpc::ServerContext* context,
                 const Odb::Grpc::HealthCheckRequest* request,

--- a/OdbDesignServer/protoc/grpc/service.proto
+++ b/OdbDesignServer/protoc/grpc/service.proto
@@ -5,6 +5,7 @@ package Odb.Grpc;
 import "design.proto";
 import "featuresfile.proto";
 import "symbolname.proto";
+import "standardfontsfile.proto";
 //import "common.proto";
 
 // Service definition for ODB++ data
@@ -25,6 +26,11 @@ service OdbDesignService {
   // Unary call to get the symbol list and units metadata for a layer.
   // Required to resolve FeatureRecord.sym_num into a SymbolName.
   rpc GetLayerSymbols(GetLayerSymbolsRequest) returns (GetLayerSymbolsResponse);
+
+  // Returns the standard font glyph data for a design.
+  // The client uses this to render ODB++ text features (silkscreen labels, refdes, etc.)
+  // as 3D stroke geometry.
+  rpc GetStandardFonts(GetStandardFontsRequest) returns (.Odb.Lib.Protobuf.StandardFontsFile);
 
   // A simple health check for the gRPC server
   rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
@@ -62,16 +68,20 @@ message GetLayerSymbolsResponse {
   repeated .Odb.Lib.Protobuf.SymbolName symbol_names = 4;
 }
 
-message HealthCheckRequest { 
+message GetStandardFontsRequest {
+  string design_name = 1;
+}
+
+message HealthCheckRequest {
   string service = 1;
 }
 
-message HealthCheckResponse { 
-  enum ServingStatus { 
+message HealthCheckResponse {
+  enum ServingStatus {
     UNKNOWN = 0;
-    SERVING = 1; 
-    NOT_SERVING = 2; 
-  } 
+    SERVING = 1;
+    NOT_SERVING = 2;
+  }
   ServingStatus status = 1;
 }
 

--- a/OdbDesignTests/CMakeLists.txt
+++ b/OdbDesignTests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(OdbDesignTests
     # gRPC methods can be unit-tested directly (used by GetStandardFontsTests.cpp).
     "../OdbDesignServer/Services/OdbDesignServiceImpl.cpp"
     "GetStandardFontsTests.cpp"
+    "GetLayerSymbolsTests.cpp"
 
     # NOTE: GrpcBatchStreamTests.cpp temporarily disabled due to CMake coupling concerns
     # Future: Will create separate test target for server component tests

--- a/OdbDesignTests/CMakeLists.txt
+++ b/OdbDesignTests/CMakeLists.txt
@@ -27,11 +27,14 @@ add_executable(OdbDesignTests
     "GrpcServiceConfigTests.cpp"
     "Utf8SanitizerTests.cpp"
     "../OdbDesignServer/Config/GrpcServiceConfig.cpp"
-    
+
+    # Server service implementation compiled into the test executable so service-level
+    # gRPC methods can be unit-tested directly (used by GetStandardFontsTests.cpp).
+    "../OdbDesignServer/Services/OdbDesignServiceImpl.cpp"
+    "GetStandardFontsTests.cpp"
+
     # NOTE: GrpcBatchStreamTests.cpp temporarily disabled due to CMake coupling concerns
-    # Server source files are compiled directly into test executable, creating tight coupling
     # Future: Will create separate test target for server component tests
-    # "../OdbDesignServer/Services/OdbDesignServiceImpl.cpp"
     # "GrpcBatchStreamTests.cpp"
      "FileArchiveLoadTests.cpp")
 

--- a/OdbDesignTests/GetLayerSymbolsTests.cpp
+++ b/OdbDesignTests/GetLayerSymbolsTests.cpp
@@ -5,11 +5,6 @@
 #include "Fixtures/FileArchiveLoadFixture.h"
 #include "OdbDesignServer/Services/OdbDesignServiceImpl.h"
 
-namespace OdbDesignServer::Services
-{
-	class OdbDesignServiceImpl;
-}
-
 using namespace Odb::Test::Fixtures;
 
 class GetLayerSymbolsFixture : public FileArchiveLoadFixture

--- a/OdbDesignTests/GetStandardFontsTests.cpp
+++ b/OdbDesignTests/GetStandardFontsTests.cpp
@@ -137,8 +137,12 @@ TEST_F(GetStandardFontsFixture, ReturnsInternalForUnparseableDesign)
 	// findRootDir resolves a root, but they are empty, so ParseDesignDirectory
 	// throws (missing misc/info etc.). This forces the server's catch block,
 	// which maps to gRPC INTERNAL.
-	const auto base = std::filesystem::temp_directory_path() / "odb_badfonts_cache";
 	std::error_code ec;
+	// Resolve the system temp path (e.g. macOS /var -> /private/var) so libarchive's
+	// ARCHIVE_EXTRACT_SECURE_SYMLINKS check does not refuse to extract into it.
+	const auto tempDir = std::filesystem::weakly_canonical(std::filesystem::temp_directory_path(ec), ec);
+	ASSERT_FALSE(ec) << "temp_directory_path failed: " << ec.message();
+	const auto base = tempDir / "odb_badfonts_cache";
 	std::filesystem::create_directories(base, ec);
 	ASSERT_FALSE(ec) << "create_directories(base) failed: " << ec.message();
 

--- a/OdbDesignTests/GetStandardFontsTests.cpp
+++ b/OdbDesignTests/GetStandardFontsTests.cpp
@@ -1,12 +1,16 @@
 #include <cctype>
 #include <cmath>
-#include <iostream>
+#include <filesystem>
+#include <memory>
+#include <random>
 #include <set>
 #include <string>
+#include <system_error>
 
 #include <gtest/gtest.h>
 #include <grpcpp/server_context.h>
 
+#include "ArchiveExtractor.h"
 #include "Fixtures/FileArchiveLoadFixture.h"
 #include "OdbDesignServer/Services/OdbDesignServiceImpl.h"
 
@@ -47,18 +51,6 @@ TEST_F(GetStandardFontsFixture, ReturnsFontDataForSampleDesign)
 	EXPECT_GT(resp.m_characterblocks_size(), 0);
 	EXPECT_GT(resp.xsize(), 0.0);
 	EXPECT_GT(resp.ysize(), 0.0);
-
-	// Surface the font size for the client handoff doc / memory estimation.
-	int lineRecordCount = 0;
-	for (const auto& block : resp.m_characterblocks())
-	{
-		lineRecordCount += block.m_linerecords_size();
-	}
-	std::cout << "[GetStandardFonts] sample_design character_blocks=" << resp.m_characterblocks_size()
-		<< " line_records=" << lineRecordCount
-		<< " xSize=" << resp.xsize()
-		<< " ySize=" << resp.ysize()
-		<< " offset=" << resp.offset() << std::endl;
 }
 
 TEST_F(GetStandardFontsFixture, ReturnsNotFoundForMissingDesign)
@@ -137,4 +129,43 @@ TEST_F(GetStandardFontsFixture, LineRecordsArePopulated)
 	}
 
 	EXPECT_GT(lineRecordCount, 0);
+}
+
+TEST_F(GetStandardFontsFixture, ReturnsInternalForUnparseableDesign)
+{
+	// Build a malformed ODB++ archive: it has the required top-level dirs so
+	// findRootDir resolves a root, but they are empty, so ParseDesignDirectory
+	// throws (missing misc/info etc.). This forces the server's catch block,
+	// which maps to gRPC INTERNAL.
+	const auto base = std::filesystem::temp_directory_path() / "odb_badfonts_cache";
+	std::error_code ec;
+	std::filesystem::create_directories(base, ec);
+	ASSERT_FALSE(ec) << "create_directories(base) failed: " << ec.message();
+
+	std::random_device rd;
+	auto cacheDir = base / (std::to_string(rd()) + "_" + std::to_string(rd()));
+	auto srcRoot = cacheDir / "src" / "bad_design";
+	for (const auto* sub : { "fonts", "misc", "matrix", "steps" })
+	{
+		std::filesystem::create_directories(srcRoot / sub, ec);
+		ASSERT_FALSE(ec) << "create_directories failed: " << ec.message();
+	}
+
+	std::string createdArchivePath;
+	ASSERT_TRUE(Utils::ArchiveExtractor::CompressDir(
+		srcRoot.string(), cacheDir.string(), "bad_design", createdArchivePath));
+	ASSERT_FALSE(createdArchivePath.empty());
+
+	auto badCache = std::make_shared<Odb::Lib::App::DesignCache>(cacheDir.string());
+	auto service = std::make_unique<OdbDesignServer::Services::OdbDesignServiceImpl>(badCache);
+
+	grpc::ServerContext ctx;
+	Odb::Grpc::GetStandardFontsRequest req;
+	Odb::Lib::Protobuf::StandardFontsFile resp;
+	req.set_design_name("bad_design");
+
+	auto status = service->GetStandardFonts(&ctx, &req, &resp);
+	EXPECT_EQ(status.error_code(), grpc::StatusCode::INTERNAL);
+
+	std::filesystem::remove_all(cacheDir, ec);
 }

--- a/OdbDesignTests/GetStandardFontsTests.cpp
+++ b/OdbDesignTests/GetStandardFontsTests.cpp
@@ -1,0 +1,140 @@
+#include <cctype>
+#include <cmath>
+#include <iostream>
+#include <set>
+#include <string>
+
+#include <gtest/gtest.h>
+#include <grpcpp/server_context.h>
+
+#include "Fixtures/FileArchiveLoadFixture.h"
+#include "OdbDesignServer/Services/OdbDesignServiceImpl.h"
+
+using namespace Odb::Test::Fixtures;
+
+namespace
+{
+	constexpr const char* SAMPLE_DESIGN = "sample_design";
+}
+
+class GetStandardFontsFixture : public FileArchiveLoadFixture
+{
+protected:
+	void SetUp() override
+	{
+		FileArchiveLoadFixture::SetUp();
+		// Convert unique_ptr to shared_ptr for the service constructor.
+		// Store shared_ptr first so ownership is captured before any potential exceptions.
+		m_sharedDesignCache = std::shared_ptr<Odb::Lib::App::DesignCache>(m_pDesignCache.release());
+		m_service = std::make_unique<OdbDesignServer::Services::OdbDesignServiceImpl>(m_sharedDesignCache);
+	}
+
+	std::shared_ptr<Odb::Lib::App::DesignCache> m_sharedDesignCache;
+	std::unique_ptr<OdbDesignServer::Services::OdbDesignServiceImpl> m_service;
+};
+
+TEST_F(GetStandardFontsFixture, ReturnsFontDataForSampleDesign)
+{
+	grpc::ServerContext ctx;
+	Odb::Grpc::GetStandardFontsRequest req;
+	Odb::Lib::Protobuf::StandardFontsFile resp;
+
+	req.set_design_name(SAMPLE_DESIGN);
+
+	auto status = m_service->GetStandardFonts(&ctx, &req, &resp);
+	ASSERT_TRUE(status.ok()) << status.error_message();
+
+	EXPECT_GT(resp.m_characterblocks_size(), 0);
+	EXPECT_GT(resp.xsize(), 0.0);
+	EXPECT_GT(resp.ysize(), 0.0);
+
+	// Surface the font size for the client handoff doc / memory estimation.
+	int lineRecordCount = 0;
+	for (const auto& block : resp.m_characterblocks())
+	{
+		lineRecordCount += block.m_linerecords_size();
+	}
+	std::cout << "[GetStandardFonts] sample_design character_blocks=" << resp.m_characterblocks_size()
+		<< " line_records=" << lineRecordCount
+		<< " xSize=" << resp.xsize()
+		<< " ySize=" << resp.ysize()
+		<< " offset=" << resp.offset() << std::endl;
+}
+
+TEST_F(GetStandardFontsFixture, ReturnsNotFoundForMissingDesign)
+{
+	grpc::ServerContext ctx;
+	Odb::Grpc::GetStandardFontsRequest req;
+	Odb::Lib::Protobuf::StandardFontsFile resp;
+
+	req.set_design_name("does_not_exist");
+
+	auto status = m_service->GetStandardFonts(&ctx, &req, &resp);
+	EXPECT_EQ(status.error_code(), grpc::StatusCode::NOT_FOUND);
+}
+
+TEST_F(GetStandardFontsFixture, ContainsExpectedCharacterSet)
+{
+	grpc::ServerContext ctx;
+	Odb::Grpc::GetStandardFontsRequest req;
+	Odb::Lib::Protobuf::StandardFontsFile resp;
+
+	req.set_design_name(SAMPLE_DESIGN);
+
+	auto status = m_service->GetStandardFonts(&ctx, &req, &resp);
+	ASSERT_TRUE(status.ok()) << status.error_message();
+
+	std::set<char> characters;
+	for (const auto& block : resp.m_characterblocks())
+	{
+		// Each glyph key must be a single printable character.
+		ASSERT_EQ(block.character().size(), 1u) << "unexpected character key: \"" << block.character() << "\"";
+		const char c = block.character()[0];
+		EXPECT_TRUE(std::isprint(static_cast<unsigned char>(c)) != 0) << "non-printable character key: " << static_cast<int>(c);
+		characters.insert(c);
+	}
+
+	// Alphanumerics are guaranteed by the ODB++ standard font.
+	for (char c = 'A'; c <= 'Z'; ++c)
+	{
+		EXPECT_TRUE(characters.count(c) > 0) << "missing glyph for: " << c;
+	}
+	for (char c = '0'; c <= '9'; ++c)
+	{
+		EXPECT_TRUE(characters.count(c) > 0) << "missing glyph for: " << c;
+	}
+
+	// Common silkscreen punctuation used by refdes / labels.
+	for (const char c : { '+', '-', '.', '_' })
+	{
+		EXPECT_TRUE(characters.count(c) > 0) << "missing glyph for: " << c;
+	}
+}
+
+TEST_F(GetStandardFontsFixture, LineRecordsArePopulated)
+{
+	grpc::ServerContext ctx;
+	Odb::Grpc::GetStandardFontsRequest req;
+	Odb::Lib::Protobuf::StandardFontsFile resp;
+
+	req.set_design_name(SAMPLE_DESIGN);
+
+	auto status = m_service->GetStandardFonts(&ctx, &req, &resp);
+	ASSERT_TRUE(status.ok()) << status.error_message();
+
+	int lineRecordCount = 0;
+	for (const auto& block : resp.m_characterblocks())
+	{
+		for (const auto& lr : block.m_linerecords())
+		{
+			++lineRecordCount;
+			EXPECT_TRUE(std::isfinite(lr.xstart()));
+			EXPECT_TRUE(std::isfinite(lr.ystart()));
+			EXPECT_TRUE(std::isfinite(lr.xend()));
+			EXPECT_TRUE(std::isfinite(lr.yend()));
+			EXPECT_GT(lr.width(), 0.0);
+		}
+	}
+
+	EXPECT_GT(lineRecordCount, 0);
+}

--- a/plan_docs/Server-Handoff-StandardFonts-Endpoint.md
+++ b/plan_docs/Server-Handoff-StandardFonts-Endpoint.md
@@ -1,0 +1,287 @@
+# Server Handoff Spec: Standard Fonts gRPC Endpoint
+
+> **To:** Server Development Agent  
+> **From:** 3D Client Development Agent  
+> **Date:** 2026-08-01  
+> **Repo:** `nam20485/OdbDesign` branch `nam20485`  
+> **Priority:** Required for client-side silkscreen/text rendering (Issue I3)
+
+---
+
+## 1. What I Need (One Sentence)
+
+A new gRPC endpoint that returns the already-parsed `StandardFontsFile` protobuf message for a given design, so the client can render ODB++ text features as 3D stroke geometry.
+
+---
+
+## 2. Why This Is Simple
+
+The server **already does 90% of the work**:
+
+| Step | Status | Evidence |
+|------|--------|----------|
+| Parse `fonts/standard` from ODB++ archive | ✅ Done | `FileArchive::ParseStandardFontsFile()` called during `ParseFileModel()` |
+| Store parsed font data in memory | ✅ Done | `FileArchive::m_standardFontsFile` member |
+| Public accessor | ✅ Done | `FileArchive::GetStandardFontsFile() const` |
+| Protobuf serialization | ✅ Done | `StandardFontsFile::to_protobuf()` |
+| Protobuf schema | ✅ Done | `standardfontsfile.proto` — `StandardFontsFile`, `CharacterBlock`, `LineRecord` |
+| Design cache has FileArchive | ✅ Done | `DesignCache::GetFileArchive(designName)` returns the archive |
+
+**The only missing piece:** A gRPC RPC method in `OdbDesignServiceImpl` that calls `fileArchive->GetStandardFontsFile().to_protobuf()` and returns it.
+
+---
+
+## 3. Interface Contract
+
+### 3.1 New RPC Method
+
+Add to `service.proto` in the `OdbDesignService` service definition:
+
+```protobuf
+// Returns the standard font glyph data for a design.
+// The client uses this to render ODB++ text features (silkscreen labels, refdes, etc.)
+// as 3D stroke geometry.
+rpc GetStandardFonts(GetStandardFontsRequest) returns (.Odb.Lib.Protobuf.StandardFontsFile);
+```
+
+### 3.2 Request Message
+
+```protobuf
+message GetStandardFontsRequest {
+    string design_name = 1;
+}
+```
+
+### 3.3 Response Message
+
+Use the **existing** `StandardFontsFile` message from `standardfontsfile.proto` — no new message types needed:
+
+```protobuf
+// Already defined in standardfontsfile.proto — DO NOT MODIFY
+message StandardFontsFile {
+    message CharacterBlock {
+        message LineRecord {
+            optional double xStart = 1;
+            optional double yStart = 2;
+            optional double xEnd = 3;
+            optional double yEnd = 4;
+            optional Polarity polarity = 5;
+            optional LineShape shape = 6;
+            optional double width = 7;
+        }
+        optional string character = 1;
+        repeated LineRecord m_lineRecords = 2;
+    }
+    optional double xSize = 1;
+    optional double ySize = 2;
+    optional double offset = 3;
+    repeated CharacterBlock m_characterBlocks = 4;
+}
+```
+
+### 3.4 Import Required
+
+In `service.proto`, add:
+
+```protobuf
+import "standardfontsfile.proto";
+```
+
+---
+
+## 4. Server Implementation
+
+### 4.1 Method Implementation in `OdbDesignServiceImpl.cpp`
+
+Follow the exact same pattern as `GetLayerSymbols` — lookup design from cache, return protobuf:
+
+```cpp
+grpc::Status OdbDesignServiceImpl::GetStandardFonts(
+    grpc::ServerContext* context,
+    const Odb::Grpc::GetStandardFontsRequest* request,
+    Odb::Lib::Protobuf::StandardFontsFile* response)
+{
+    try
+    {
+        loginfo("[ConnTrace] GetStandardFonts start: design_name=\"" + request->design_name() + "\"");
+
+        const auto fileArchive = m_designCache->GetFileArchive(request->design_name());
+        if (fileArchive == nullptr)
+        {
+            return {grpc::StatusCode::NOT_FOUND, "Design not found: " + request->design_name()};
+        }
+
+        const auto& fontsFile = fileArchive->GetStandardFontsFile();
+        *response = *fontsFile.to_protobuf();
+
+        loginfo("[ConnTrace] GetStandardFonts done: design_name=\"" + request->design_name() +
+            "\" characters=" + std::to_string(response->m_characterblocks_size()));
+
+        return grpc::Status::OK;
+    }
+    catch (const std::exception& e)
+    {
+        std::string error = "Internal server error: " + std::string(e.what());
+        return {grpc::StatusCode::INTERNAL, error};
+    }
+}
+```
+
+### 4.2 Header Declaration in `OdbDesignServiceImpl.h`
+
+```cpp
+grpc::Status GetStandardFonts(
+    grpc::ServerContext* context,
+    const Odb::Grpc::GetStandardFontsRequest* request,
+    Odb::Lib::Protobuf::StandardFontsFile* response) override;
+```
+
+### 4.3 Include Required
+
+In `OdbDesignServiceImpl.cpp`, add:
+
+```cpp
+#include <standardfontsfile.pb.h>
+```
+
+---
+
+## 5. Error Handling Contract
+
+| Condition | gRPC Status | Message |
+|-----------|-------------|---------|
+| Design not found in cache | `NOT_FOUND` | `"Design not found: <name>"` |
+| `fonts/standard` was missing during parse (archive has no fonts) | `OK` with empty `StandardFontsFile` (0 character blocks) | N/A — not an error |
+| Unexpected exception | `INTERNAL` | `"Internal server error: <details>"` |
+
+**Important:** If the ODB++ archive has no `fonts/` directory, `ParseStandardFontsFile` throws `invalid_odb_error` during `ParseFileModel()`. This means the design would never load into the cache in the first place. So by the time `GetStandardFonts` is called, the font data is guaranteed to exist (possibly empty if the `fonts/standard` file exists but contains no characters).
+
+If you want to be defensive: catch the case where `m_characterBlocks` is empty and still return `OK` — the client will simply render no text.
+
+---
+
+## 6. Data Model Reference (What the Client Receives)
+
+### 6.1 `StandardFontsFile` (top-level)
+
+| Field | Type | Description | Client Usage |
+|-------|------|-------------|--------------|
+| `xSize` | `double` | Font's native X cell size (font coordinate units) | Scale factor: `textFeature.xsize / font.xSize` |
+| `ySize` | `double` | Font's native Y cell size (font coordinate units) | Scale factor: `textFeature.ysize / font.ySize` |
+| `offset` | `double` | Baseline offset in font units | Vertical offset when placing glyphs |
+| `m_characterBlocks` | `repeated CharacterBlock` | All character glyph definitions | Lookup by `character` string |
+
+### 6.2 `CharacterBlock` (one per character)
+
+| Field | Type | Description | Client Usage |
+|-------|------|-------------|--------------|
+| `character` | `string` | The character this block defines (e.g., `"A"`, `"1"`, `"+"`) | Key for lookup: `text[i]` → find matching block |
+| `m_lineRecords` | `repeated LineRecord` | Stroke segments that draw this character | Render each as a 3D line segment |
+
+### 6.3 `LineRecord` (one stroke segment)
+
+| Field | Type | Description | Client Usage |
+|-------|------|-------------|--------------|
+| `xStart` | `double` | Stroke start X in font units | Scale by `xScale`, translate to text position |
+| `yStart` | `double` | Stroke start Y in font units | Scale by `yScale`, translate to text position |
+| `xEnd` | `double` | Stroke end X in font units | Scale by `xScale`, translate to text position |
+| `yEnd` | `double` | Stroke end Y in font units | Scale by `yScale`, translate to text position |
+| `polarity` | `Polarity` | `Positive` (0) or `Negative` (1) | Negative = erase/clear (client may skip or render differently) |
+| `shape` | `LineShape` | `Square` (0) or `Round` (1) | Line cap style (client uses round caps for Round, flat for Square) |
+| `width` | `double` | Stroke width in font units | Scale by `xScale` for 3D line thickness |
+
+### 6.4 Enums (from `enums.proto`)
+
+```protobuf
+enum LineShape { Square = 0; Round = 1; }
+enum Polarity { Positive = 0; Negative = 1; }
+```
+
+---
+
+## 7. How the Client Uses This Data (For Your Context)
+
+When the client receives a `Text` feature from `GetLayerFeaturesStream`:
+
+```
+Text feature fields used:
+  .text          = "R70"           // The string to render
+  .font          = "standard"      // Font name (always "standard" for ODB++ spec)
+  .x             = 1234.5          // X position in layer units
+  .y             = 678.9           // Y position in layer units
+  .xsize         = 1.5             // Character height in layer units
+  .ysize         = 1.0             // Character width in layer units
+  .width_factor  = 0.1             // Stroke width multiplier
+  .orient_def    = 0               // Orientation code (0-9)
+  .orient_def_rotation = 0.0      // Custom rotation (only for orient_def 8,9)
+```
+
+The client then:
+
+1. Looks up the `StandardFontsFile` (cached from `GetStandardFonts` call)
+2. For each character in `.text`, finds the matching `CharacterBlock` by `.character`
+3. For each `LineRecord` in the block, computes the 3D line segment:
+   ```
+   xScale = textFeature.xsize / font.xSize
+   yScale = textFeature.ysize / font.ySize
+   strokeThickness = lineRecord.width * xScale * textFeature.width_factor
+
+   // Apply orientation rotation (orient_def → angle)
+   // Translate to (textFeature.x, textFeature.y) in layer coordinates
+   // Map to 3D: (pcbX, layerYLevel, pcbY)
+   ```
+4. Renders each segment as a 3D line using the existing `LineRenderer`
+
+**The client needs `xSize` and `ySize` from the font to compute the scale factors.** Without them, glyph coordinates cannot be properly mapped to the text feature's physical size.
+
+---
+
+## 8. Client-Side Call Flow
+
+```
+1. User selects Design → client calls GetDesign or GetStandardFonts
+2. Client caches StandardFontsFile in memory (design-level, not layer-level)
+3. User selects Step → layers load
+4. Client streams features via GetLayerFeaturesStream
+5. When a Text feature arrives, client looks up cached font data
+6. Client renders text as 3D stroke lines
+```
+
+The client will call `GetStandardFonts` **once per design selection**, not per layer. The response is small (typical standard font = ~95 characters × ~5 line records each = ~475 line records, a few KB of protobuf).
+
+---
+
+## 9. Testing Checklist
+
+After implementation, verify:
+
+- [ ] `GetStandardFonts("sample_design")` returns `OK` with `m_characterblocks_size() > 0`
+- [ ] `GetStandardFonts("nonexistent")` returns `NOT_FOUND`
+- [ ] Response contains `xSize > 0` and `ySize > 0`
+- [ ] Response contains character blocks for at least: `A-Z`, `0-9`, `+`, `-`, `.`, `_`
+- [ ] Each `CharacterBlock.character` is a single printable character
+- [ ] Each `LineRecord` has `xStart`, `yStart`, `xEnd`, `yEnd` populated
+- [ ] `LineRecord.width` is populated and > 0
+- [ ] Response protobuf deserializes correctly on the client (C# `StandardFontsFile` class)
+
+---
+
+## 10. Open Questions
+
+1. **Custom fonts:** Does any test design use fonts other than `"standard"`? If yes, the server may need to support multiple font files (e.g., `fonts/simplex`, `fonts/complex`). For now, the client assumes only `"standard"` exists. If custom fonts are needed, the response should include a `map<string, StandardFontsFile>` keyed by font name instead of a single `StandardFontsFile`.
+
+2. **Font data size:** For the `sample_design` test archive, how many character blocks and line records does the standard font contain? This helps the client estimate memory and rendering cost.
+
+3. **`offset` field:** What is the semantic meaning of `StandardFontsFile.offset`? Is it a Y-axis baseline offset in font units? The client needs to know whether to add or subtract this when positioning glyphs.
+
+---
+
+## 11. Summary of Changes Required
+
+| File | Change |
+|------|--------|
+| `Protos/grpc/service.proto` | Add `import "standardfontsfile.proto";`, add `GetStandardFonts` RPC, add `GetStandardFontsRequest` message |
+| `OdbDesignServer/Services/OdbDesignServiceImpl.h` | Add `GetStandardFonts` method declaration |
+| `OdbDesignServer/Services/OdbDesignServiceImpl.cpp` | Add `GetStandardFonts` method implementation (~20 lines) |
+
+**Total estimated effort: 30 minutes.** No new parsing, no new data models, no new dependencies. The data is already parsed, stored, and serializable — it just needs a gRPC accessor.

--- a/plan_docs/Server-Handoff-StandardFonts-Implementation.md
+++ b/plan_docs/Server-Handoff-StandardFonts-Implementation.md
@@ -1,0 +1,209 @@
+# Server Handoff: `GetStandardFonts` gRPC Endpoint — Implementation Notes
+
+> **To:** 3D Client Development Team
+> **From:** Server Development
+> **Date:** 2026-08-01
+> **Repo:** `nam20485/OdbDesign`, branch `nam20485`
+> **In response to:** `plan_docs/Server-Handoff-StandardFonts-Endpoint.md`
+> **Status:** Implemented, tested, and validated (129/129 server tests passing).
+
+---
+
+## 1. Summary
+
+The `GetStandardFonts` endpoint is implemented exactly as specified in your handoff
+spec. It is a unary RPC on the existing `OdbDesignService` that returns the
+already-parsed `StandardFontsFile` protobuf for a given design. No new data models,
+no schema changes to `standardfontsfile.proto`, and no changes to the parsing pipeline
+— the font data was already parsed, stored, and serializable; this adds the gRPC
+accessor only.
+
+---
+
+## 2. RPC Contract
+
+Added to `service OdbDesignService` in `OdbDesignServer/protoc/grpc/service.proto`:
+
+```protobuf
+// Returns the standard font glyph data for a design.
+// The client uses this to render ODB++ text features (silkscreen labels, refdes, etc.)
+// as 3D stroke geometry.
+rpc GetStandardFonts(GetStandardFontsRequest) returns (.Odb.Lib.Protobuf.StandardFontsFile);
+```
+
+### Request
+
+```protobuf
+message GetStandardFontsRequest {
+  string design_name = 1;   // same design_name used by GetDesign / GetLayerFeaturesStream
+}
+```
+
+### Response
+
+The **existing, unmodified** `Odb.Lib.Protobuf.StandardFontsFile` message from
+`standardfontsfile.proto` (schema reproduced in your spec §3.3 / §6). Field numbers
+and types are unchanged.
+
+### Proto files your client stub must compile
+
+`service.proto` transitively depends on the library protos. To generate a client stub
+you need these on your proto include path (all in `OdbDesignLib/protoc/` except
+`service.proto`):
+
+| File | Why |
+|------|-----|
+| `OdbDesignServer/protoc/grpc/service.proto` | service + `GetStandardFontsRequest` |
+| `standardfontsfile.proto` | response message |
+| `enums.proto` | `Polarity`, `LineShape` used by `LineRecord` |
+| `design.proto`, `featuresfile.proto`, `symbolname.proto` | other RPCs on the same service (required to compile `service.proto`) |
+
+---
+
+## 3. Error Handling Contract (as implemented)
+
+| Condition | gRPC Status | Message |
+|-----------|-------------|---------|
+| Design not loaded / unknown `design_name` | `NOT_FOUND` | `"Design not found: <design_name>"` |
+| Archive has no `fonts/` or no `fonts/standard` | *(cannot occur at call time — see note)* | — |
+| Unexpected server exception | `INTERNAL` | `"Internal server error: <details>"` |
+| Success (including an empty font) | `OK` | — |
+
+**Note on missing fonts:** `fonts/standard` is mandatory per the ODB++ spec, and the
+server throws during design load (`ParseFileModel`) if it is absent. Such a design
+never enters the cache, so `GetStandardFonts` can only ever be called for a design
+whose font data exists. A font file that parses but defines no glyphs returns `OK`
+with `m_characterBlocks` empty (0 blocks) — render no text, not an error.
+
+---
+
+## 4. Data Model — Confirmed Field Usage
+
+Your spec §6 is correct. Quick confirmation of the wire field names (proto) and the
+PascalCase properties `protoc` generates for C#:
+
+| Proto field | C# property | Type | Notes |
+|-------------|-------------|------|-------|
+| `xSize` | `XSize` | `double` | Font native X cell size (font units). Scale: `textFeature.xsize / XSize`. |
+| `ySize` | `YSize` | `double` | Font native Y cell size (font units). Scale: `textFeature.ysize / YSize`. |
+| `offset` | `Offset` | `double` | Baseline offset (font units). See Open Question 3. |
+| `m_characterBlocks` | `MCharacterBlocks` | `repeated CharacterBlock` | Lookup by `character`. |
+| `CharacterBlock.character` | `Character` | `string` | Single printable character (e.g. `"A"`, `"1"`, `"+"`). |
+| `CharacterBlock.m_lineRecords` | `MLineRecords` | `repeated LineRecord` | Stroke segments for the glyph. |
+| `LineRecord.xStart/yStart/xEnd/yEnd` | `XStart/YStart/XEnd/YEnd` | `double` | Segment endpoints (font units). |
+| `LineRecord.polarity` | `Polarity` | `enum` | `Positive=0`, `Negative=1`. |
+| `LineRecord.shape` | `Shape` | `enum` | `Square=0`, `Round=1`. |
+| `LineRecord.width` | `Width` | `double` | Stroke width (font units); always `> 0`. |
+
+All `LineRecord` coordinate/width fields are populated for every record (the parser
+requires them), so you do not need to guard against missing sub-fields beyond the
+proto3 `optional` presence semantics.
+
+---
+
+## 5. Recommended Client Call Flow
+
+Unchanged from your spec §8 — confirmed this matches server behavior:
+
+1. On design selection, call `GetStandardFonts(design_name)` **once**.
+2. Cache the `StandardFontsFile` at design scope (not per layer).
+3. Stream features via `GetLayerFeaturesStream` / `GetLayerFeaturesBatchStream`.
+4. For each `Text` feature, look up glyphs by character and scale by
+   `xsize / XSize` and `ysize / YSize`.
+
+The response is small (see §7), so caching it for the whole design session is cheap.
+
+---
+
+## 6. Implementation Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Response reuses `StandardFontsFile` directly (no wrapper message). | Matches your spec; avoids an extra type. A design has exactly one standard font, so no map/key is needed. |
+| `NOT_FOUND` keyed only on `design_name`. | The endpoint is design-scoped; there is no step/layer input. Mirrors `GetDesign`. |
+| Empty font returns `OK`, not an error. | A parseable-but-empty font is valid; the client simply renders no text. |
+| Server passes `offset` through verbatim. | The server does not interpret font semantics; it serializes the parsed value as-is. |
+| Service-level unit tests re-enabled in the server test target. | Allowed direct testing of gRPC status codes (`OK` / `NOT_FOUND`) and payload invariants. |
+
+---
+
+## 7. Answers to Your Open Questions
+
+### Q1 — Custom fonts: does any test design use fonts other than `"standard"`?
+
+**No.** Verified two ways:
+
+- **Server code:** only `fonts/standard` is ever parsed (`FileArchive::ParseStandardFontsFile`
+  → `StandardFontsFile::Parse` opens `<design>/fonts/standard`). Any other font file in an
+  archive (e.g. `fonts/simplex`) is ignored — there is no parser or storage for it.
+- **Test archives:** both `sample_design.tgz` and `designodb_rigidflex.tgz` contain exactly
+  one font file: `fonts/standard`. No other font files are present.
+
+**Conclusion:** your assumption that only `"standard"` exists is correct for all current
+test data, and the single-`StandardFontsFile` response is the right shape. If custom fonts
+are ever required, it would be a server-side change (parse additional font files and switch
+the response to `map<string, StandardFontsFile>`); we would version the RPC rather than
+change this one.
+
+### Q2 — Font data size for `sample_design`
+
+Measured directly from the endpoint response:
+
+| Metric | Value |
+|--------|-------|
+| `m_characterBlocks` | **94** |
+| total `LineRecord`s (across all blocks) | **446** (≈ 4.7 strokes/glyph) |
+| `xSize` | **0.302** |
+| `ySize` | **0.302** |
+| `offset` | **0** |
+
+This is on the order of a few KB of protobuf — trivial to cache for the design session.
+Your §8 estimate (~95 chars × ~5 records) was essentially exact.
+
+### Q3 — Semantic meaning of `offset`
+
+`offset` is the value of the `OFFSET` directive in the ODB++ `fonts/standard` file header
+(alongside `XSIZE` / `YSIZE`), expressed in **font units**. Per the ODB++ standard-font
+format it is a **vertical (Y-axis) baseline offset** — the displacement of the glyph
+baseline relative to the character-cell origin.
+
+Guidance for placement:
+
+- Apply it on the Y axis, scaled the same way as glyph Y coordinates
+  (`yScale = textFeature.ysize / YSize`), i.e. `yOffsetWorld = Offset * yScale`.
+- Treat a positive value as a `+Y` shift of the baseline.
+- For both current test designs `offset == 0`, so it has no visible effect there; still
+  honor it so archives with a non-zero baseline render correctly.
+
+Caveat: the server stores and returns this value verbatim and does not interpret it, so the
+authoritative definition is the ODB++ spec's `fonts/standard` `OFFSET` directive. If you
+obtain a reference design with a non-zero `offset`, use it to confirm the sign convention
+against your renderer; the magnitude and axis (Y, font units) are as stated above.
+
+---
+
+## 8. Validation Evidence
+
+- New endpoint tests (`OdbDesignTests/GetStandardFontsTests.cpp`), all passing:
+  - `ReturnsFontDataForSampleDesign` — `OK`, `>0` blocks, `XSize>0`, `YSize>0`.
+  - `ReturnsNotFoundForMissingDesign` — `NOT_FOUND`.
+  - `ContainsExpectedCharacterSet` — glyphs for `A–Z`, `0–9`, `+ - . _`; each key a single printable char.
+  - `LineRecordsArePopulated` — every record has finite coordinates and `Width>0`.
+- Full server suite: **129/129 tests pass** (serial run).
+
+> **Heads-up on parallel test runs:** the server's design-loading test fixtures share one
+> `TEST_DATA` directory and are **not parallel-safe** — `ctest -j$(nproc)` produces
+> intermittent failures (concurrent extract/delete races) unrelated to this change. Run the
+> suite serially (`ctest --preset linux-debug`) for a clean result.
+
+---
+
+## 9. Files Changed (server side)
+
+| File | Change |
+|------|--------|
+| `OdbDesignServer/protoc/grpc/service.proto` | `import "standardfontsfile.proto";`, `GetStandardFonts` RPC, `GetStandardFontsRequest` message |
+| `OdbDesignServer/Services/OdbDesignServiceImpl.h` | `GetStandardFonts` override declaration |
+| `OdbDesignServer/Services/OdbDesignServiceImpl.cpp` | `GetStandardFonts` implementation |
+| `OdbDesignTests/CMakeLists.txt` | re-enabled service impl in test target; registered new tests |
+| `OdbDesignTests/GetStandardFontsTests.cpp` | new service-level tests |

--- a/plan_docs/Server-StandardFonts-Implementation-Plan.md
+++ b/plan_docs/Server-StandardFonts-Implementation-Plan.md
@@ -1,0 +1,115 @@
+# Implementation Plan: `GetStandardFonts` gRPC Endpoint
+
+> **Companion to:** `plan_docs/Server-Handoff-StandardFonts-Endpoint.md` (client-authored spec)
+> **Branch:** `nam20485`
+> **Date:** 2026-08-01
+
+---
+
+## 1. Objective
+
+Expose the already-parsed `StandardFontsFile` protobuf message over gRPC so the 3D
+client can render ODB++ text features (silkscreen labels, refdes, etc.) as stroke
+geometry. The parsing, in-memory storage, and protobuf serialization already exist;
+this work adds only the gRPC accessor, its request message, and tests.
+
+---
+
+## 2. Findings From Code Analysis
+
+| Concern | Finding | Source |
+|---------|---------|--------|
+| Proto import resolution | `service.proto` is compiled with `IMPORT_DIRS ${GRPC_PROTO_DIR} ${PROTO_DIR}` where `PROTO_DIR = OdbDesignLib/protoc`. `import "standardfontsfile.proto"` resolves with no CMake change. | `OdbDesignServer/CMakeLists.txt` |
+| Generated header visibility | `standardfontsfile.pb.h` is already visible to the server target via the same path that provides `design.pb.h` / `featuresfile.pb.h` (server links `OdbDesign` PUBLIC). | `OdbDesignServiceImpl.cpp` includes |
+| Data accessor | `FileArchive::GetStandardFontsFile()` returns `const StandardFontsFile&`; `StandardFontsFile::to_protobuf()` returns `std::unique_ptr<Odb::Lib::Protobuf::StandardFontsFile>`. | `FileArchive.h`, `StandardFontsFile.h` |
+| Font data guarantee | `fonts/standard` is mandatory per ODB++ spec; `ParseStandardFontsFile` / `StandardFontsFile::Parse` throw `invalid_odb_error` if missing, so a design that loaded into the cache always has font data (possibly 0 character blocks if the file is empty). | `FileArchive.cpp`, `StandardFontsFile.cpp` |
+| Cache lookup | `DesignCache::GetFileArchive(designName)` returns `nullptr` for an unknown design — same pattern used by `GetLayerFeaturesStream` / `GetLayerSymbols`. | `DesignCache.h` |
+| **Test harness gap** | The existing gRPC service tests (`GetLayerSymbolsTests.cpp`) are **not compiled** — they are absent from the test `add_executable`, and `OdbDesignServiceImpl.cpp` is commented out of the test target with a NOTE about "CMake coupling concerns". There is currently no compiled service-level test harness. | `OdbDesignTests/CMakeLists.txt` |
+
+**Decision (approved by user):** re-enable `OdbDesignServiceImpl.cpp` in the existing
+`OdbDesignTests` target and add a new `GetStandardFontsTests.cpp` mirroring the
+`GetLayerSymbolsFixture` pattern. Both deliverable docs go in `plan_docs/`.
+
+---
+
+## 3. Changes
+
+### 3.1 `OdbDesignServer/protoc/grpc/service.proto`
+- Add `import "standardfontsfile.proto";`
+- Add to `service OdbDesignService`:
+  ```protobuf
+  rpc GetStandardFonts(GetStandardFontsRequest) returns (.Odb.Lib.Protobuf.StandardFontsFile);
+  ```
+- Add request message (package `Odb.Grpc`):
+  ```protobuf
+  message GetStandardFontsRequest {
+      string design_name = 1;
+  }
+  ```
+- Response reuses the existing `Odb.Lib.Protobuf.StandardFontsFile` message — no new
+  response type, no modification to `standardfontsfile.proto`.
+
+### 3.2 `OdbDesignServer/Services/OdbDesignServiceImpl.h`
+- Add the override declaration:
+  ```cpp
+  grpc::Status GetStandardFonts(grpc::ServerContext* context,
+      const Odb::Grpc::GetStandardFontsRequest* request,
+      Odb::Lib::Protobuf::StandardFontsFile* response) override;
+  ```
+
+### 3.3 `OdbDesignServer/Services/OdbDesignServiceImpl.cpp`
+- Add `#include <standardfontsfile.pb.h>`.
+- Implement `GetStandardFonts` following the `GetDesign` / `GetLayerSymbols` pattern:
+  - `[ConnTrace]` start log with `design_name`.
+  - `m_designCache->GetFileArchive(request->design_name())`; if `nullptr` return
+    `NOT_FOUND` with `"Design not found: <name>"`.
+  - `*response = *fileArchive->GetStandardFontsFile().to_protobuf();`
+  - `[ConnTrace]` done log including `m_characterblocks_size()`.
+  - Return `grpc::Status::OK`.
+  - `catch (const std::exception&)` → `INTERNAL` with `"Internal server error: <what>"`.
+
+### 3.4 `OdbDesignTests/CMakeLists.txt`
+- Re-enable `../OdbDesignServer/Services/OdbDesignServiceImpl.cpp` in the
+  `OdbDesignTests` `add_executable` list.
+- Add `GetStandardFontsTests.cpp` to the list.
+- (No other CMake changes: the target already links gRPC, includes the codegen dir,
+  compiles `service.pb.cc` / `service.grpc.pb.cc`, and depends on `OdbDesignServer`.)
+
+### 3.5 `OdbDesignTests/GetStandardFontsTests.cpp` (new)
+- Fixture `GetStandardFontsFixture : public FileArchiveLoadFixture` mirroring
+  `GetLayerSymbolsFixture` (constructs `OdbDesignServiceImpl` from the cache).
+- Test cases:
+  - `ReturnsFontDataForSampleDesign` — `OK`, `m_characterblocks_size() > 0`,
+    `xsize() > 0`, `ysize() > 0`; record block/line counts for the handoff doc.
+  - `ReturnsNotFoundForMissingDesign` — `NOT_FOUND`.
+  - `ContainsExpectedCharacterSet` — blocks cover `A–Z`, `0–9`, `+`, `-`, `.`, `_`;
+    each `character` is a single printable char.
+  - `LineRecordsArePopulated` — every line record has finite coordinates and
+    `width > 0`.
+
+---
+
+## 4. Verification
+
+1. `cmake --preset linux-debug`
+2. `cmake --build --preset linux-debug`
+3. `ctest --preset linux-debug -R GetStandardFonts -V` — new endpoint tests pass.
+4. `ctest --preset linux-debug` — full suite passes (confirms re-enabling the service
+   in the test target introduces no regressions).
+
+---
+
+## 5. Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Re-enabling `OdbDesignServiceImpl.cpp` in the test target revives the historical "CMake coupling" build issue. | Full build + full test run. If intractable, fall back to a data-level test (`FileArchive → to_protobuf`) and flag before doing so. |
+| `sample_design` font content differs from assumptions. | Tests assert only spec-guaranteed invariants; exact counts are captured at runtime for the handoff doc rather than hard-coded. |
+
+---
+
+## 6. Out of Scope
+
+- No changes to parsing logic, data models, or `standardfontsfile.proto`.
+- The disabled `GetLayerSymbolsTests.cpp` is left as-is (not re-registered).
+- Client-side (C#) implementation.


### PR DESCRIPTION
Add a unary GetStandardFonts RPC to OdbDesignService that returns the already-parsed StandardFontsFile protobuf for a design, so clients can render ODB++ text features (silkscreen labels, refdes) as stroke geometry. Reuses the existing StandardFontsFile message; no schema or parsing changes.

Includes service-level tests (re-enabling OdbDesignServiceImpl in the test target) and the client handoff documentation answering the spec's open questions.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>