### PR TITLE
test: make design-loading fixtures parallel-safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ gpg_keys/
 .cursor/hooks/state/continual-learning-index.json
 .qwen/settings.json
 .qwen/settings.json.orig
+.mimosa/

--- a/.idea/editor.xml
+++ b/.idea/editor.xml
@@ -192,6 +192,7 @@
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppRedundantTypenameKeyword/@EntryIndexedValue" value="WARNING" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppRedundantVoidArgumentList/@EntryIndexedValue" value="SUGGESTION" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppRedundantZeroInitializerInAggregateInitialization/@EntryIndexedValue" value="SUGGESTION" type="string" />
+    <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppReferenceToOverriddenVirtualFunction/@EntryIndexedValue" value="WARNING" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppReinterpretCastFromVoidPtr/@EntryIndexedValue" value="SUGGESTION" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppRemoveRedundantBraces/@EntryIndexedValue" value="DO_NOT_SHOW" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppReplaceMemsetWithZeroInitialization/@EntryIndexedValue" value="SUGGESTION" type="string" />
@@ -225,6 +226,7 @@
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppUseAssociativeContains/@EntryIndexedValue" value="SUGGESTION" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppUseAuto/@EntryIndexedValue" value="HINT" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppUseAutoForNumeric/@EntryIndexedValue" value="HINT" type="string" />
+    <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppUseDesignatedInitializers/@EntryIndexedValue" value="HINT" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppUseElementsView/@EntryIndexedValue" value="SUGGESTION" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppUseEraseAlgorithm/@EntryIndexedValue" value="SUGGESTION" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppUseFamiliarTemplateSyntaxForGenericLambdas/@EntryIndexedValue" value="SUGGESTION" type="string" />

--- a/OdbDesignTests/ArchiveExtractorTests.cpp
+++ b/OdbDesignTests/ArchiveExtractorTests.cpp
@@ -15,7 +15,9 @@ namespace Odb::Test
 	TEST_F(TestDataFixture, Test_ArchiveExtractor_CompressDir)
 	{
 		std::string fileArchiveOut;
-		ArchiveExtractor::CompressDir(getTestDataFilesDir().string(), getTestDataDir().string(), "files_archiveextractor", fileArchiveOut);
+		// Write the compressed output to the system temp dir, not the shared test-data
+		// directory, so parallel runs don't leave artifacts in (or race on) TEST_DATA.
+		ArchiveExtractor::CompressDir(getTestDataFilesDir().string(), temp_directory_path().string(), "files_archiveextractor", fileArchiveOut);
 
 		ASSERT_STRNE(fileArchiveOut.c_str(), "");
 		ASSERT_TRUE(exists(fileArchiveOut));

--- a/OdbDesignTests/ArchiveExtractorTests.cpp
+++ b/OdbDesignTests/ArchiveExtractorTests.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "Fixtures/TestDataFixture.h"
+#include "Fixtures/TestUtils.h"
 #include "ArchiveExtractor.h"
 #include <filesystem>
 #include <string>
@@ -7,6 +8,7 @@
 //using namespace Odb::Lib::App;
 //using namespace Odb::Lib::FileModel;
 using namespace Odb::Test::Fixtures;
+using namespace Odb::Test::Utils;
 using namespace std::filesystem;
 using namespace Utils;
 
@@ -14,10 +16,14 @@ namespace Odb::Test
 {
 	TEST_F(TestDataFixture, Test_ArchiveExtractor_CompressDir)
 	{
+		// Compress into a per-test managed temp dir rather than the shared system temp
+		// root. compress_dir() derives the output filename entirely from archiveName
+		// (no PID/unique component), so a fixed name in the shared temp root would be
+		// clobbered/raced by a concurrent invocation of this same test under ctest -j.
+		// The managed dir both uniquifies the path and removes the artifact on scope exit.
+		auto destDir = TestUtils::createManagedTempDirectory("odbtest_compress_extractor");
 		std::string fileArchiveOut;
-		// Write the compressed output to the system temp dir, not the shared test-data
-		// directory, so parallel runs don't leave artifacts in (or race on) TEST_DATA.
-		ArchiveExtractor::CompressDir(getTestDataFilesDir().string(), temp_directory_path().string(), "files_archiveextractor", fileArchiveOut);
+		ArchiveExtractor::CompressDir(getTestDataFilesDir().string(), destDir->path().string(), "files_archiveextractor", fileArchiveOut);
 
 		ASSERT_STRNE(fileArchiveOut.c_str(), "");
 		ASSERT_TRUE(exists(fileArchiveOut));

--- a/OdbDesignTests/ArchiveTests.cpp
+++ b/OdbDesignTests/ArchiveTests.cpp
@@ -15,7 +15,9 @@ namespace Odb::Test
 	TEST_F(TestDataFixture, Test_LibArchive_CompressDir)
 	{
 		std::string fileArchiveOut;
-		compress_dir(getTestDataFilesDir().string().c_str(), getTestDataDir().string().c_str(), "files_libarchive", fileArchiveOut);
+		// Write the compressed output to the system temp dir, not the shared test-data
+		// directory, so parallel runs don't leave artifacts in (or race on) TEST_DATA.
+		compress_dir(getTestDataFilesDir().string().c_str(), temp_directory_path().string().c_str(), "files_libarchive", fileArchiveOut);
 
 		ASSERT_TRUE(exists(fileArchiveOut));
 	}	

--- a/OdbDesignTests/ArchiveTests.cpp
+++ b/OdbDesignTests/ArchiveTests.cpp
@@ -1,12 +1,14 @@
 #include <gtest/gtest.h>
 #include <filesystem>
 #include "Fixtures/TestDataFixture.h"
+#include "Fixtures/TestUtils.h"
 #include "libarchive_extract.h"
 #include "ArchiveExtractor.h"
 #include <string>
 
 using namespace std::filesystem;
 using namespace Odb::Test::Fixtures;
+using namespace Odb::Test::Utils;
 using namespace testing;
 using namespace Utils;
 
@@ -14,11 +16,15 @@ namespace Odb::Test
 {
 	TEST_F(TestDataFixture, Test_LibArchive_CompressDir)
 	{
+		// Compress into a per-test managed temp dir rather than the shared system temp
+		// root. compress_dir() derives the output filename entirely from archiveName
+		// (no PID/unique component), so a fixed name in the shared temp root would be
+		// clobbered/raced by a concurrent invocation of this same test under ctest -j.
+		// The managed dir both uniquifies the path and removes the artifact on scope exit.
+		auto destDir = TestUtils::createManagedTempDirectory("odbtest_compress_libarchive");
 		std::string fileArchiveOut;
-		// Write the compressed output to the system temp dir, not the shared test-data
-		// directory, so parallel runs don't leave artifacts in (or race on) TEST_DATA.
-		compress_dir(getTestDataFilesDir().string().c_str(), temp_directory_path().string().c_str(), "files_libarchive", fileArchiveOut);
+		compress_dir(getTestDataFilesDir().string().c_str(), destDir->path().string().c_str(), "files_libarchive", fileArchiveOut);
 
 		ASSERT_TRUE(exists(fileArchiveOut));
-	}	
+	}
 }

--- a/OdbDesignTests/FileArchiveTests.cpp
+++ b/OdbDesignTests/FileArchiveTests.cpp
@@ -11,7 +11,7 @@ namespace Odb::Test
 {
 	TEST_F(FileArchiveLoadFixture, Test_DesignOdb_RigidFlexDesign_CanHasCorrectData)
 	{
-        auto rigidFlexDesignPath = getDesignPath("designodb_rigidflex.tgz");
+        auto rigidFlexDesignPath = getIsolatedDesignPath("designodb_rigidflex.tgz");
 
         Design::FileArchive rigidFlexOdbDesign(rigidFlexDesignPath.string());
         auto success = rigidFlexOdbDesign.ParseFileModel();
@@ -84,7 +84,7 @@ namespace Odb::Test
 
     TEST_F(FileArchiveLoadFixture, Test_SampleDesign_CanHasCorrectData)
     {
-        auto rigidFlexDesignPath = getDesignPath("sample_design.tgz");
+        auto rigidFlexDesignPath = getIsolatedDesignPath("sample_design.tgz");
 
         Design::FileArchive rigidFlexOdbDesign(rigidFlexDesignPath.string());
         auto success = rigidFlexOdbDesign.ParseFileModel();

--- a/OdbDesignTests/Fixtures/FileArchiveLoadFixture.cpp
+++ b/OdbDesignTests/Fixtures/FileArchiveLoadFixture.cpp
@@ -5,53 +5,105 @@
 #include <cstdlib>
 #include "App/DesignCache.h"
 #include "TestDataFixture.h"
+#include "ArchiveExtractor.h"
 #include <filesystem>
+#include <random>
+#include <atomic>
+#include <sstream>
+#include <system_error>
+#include <cstdint>
 
 using namespace std::filesystem;
-//using namespace Odb::Lib;
-using namespace Odb::Lib::App;
 using namespace Utils;
+using namespace Odb::Lib::App;
+
+namespace
+{
+	// Creates a unique, per-fixture scratch directory under the system temp dir.
+	// Each test fixture instance gets its own directory so concurrent test processes
+	// never extract into or delete from a shared on-disk location.
+	std::filesystem::path createUniqueScratchDir()
+	{
+		std::error_code ec;
+		auto base = std::filesystem::temp_directory_path() / "odbdesign_tests";
+		std::filesystem::create_directories(base, ec);
+
+		static std::atomic<uint64_t> counter{ 0 };
+		std::random_device rd;
+		std::mt19937_64 gen((static_cast<uint64_t>(rd()) << 32) ^ rd());
+		std::uniform_int_distribution<uint64_t> dist;
+
+		for (;;)
+		{
+			std::ostringstream name;
+			name << std::hex << dist(gen) << "_" << std::hex << counter.fetch_add(1);
+
+			auto candidate = base / name.str();
+			// create_directory atomically succeeds only if the dir does not yet exist.
+			if (std::filesystem::create_directory(candidate, ec))
+			{
+				return candidate;
+			}
+		}
+	}
+}
 
 namespace Odb::Test::Fixtures
 {
 	FileArchiveLoadFixture::FileArchiveLoadFixture()
 		: m_pDesignCache(nullptr)
-	{		
+	{
 	}
 
 	void FileArchiveLoadFixture::SetUp()
 	{
 		TestDataFixture::SetUp();
 
-		m_pDesignCache = std::unique_ptr<DesignCache>(new DesignCache(getTestDataDir().string()));
+		m_scratchDir = createUniqueScratchDir();
+
+		// Copy the design archives into the isolated scratch dir so that extraction
+		// (which writes next to the archive) happens per-fixture instead of in the
+		// shared test-data directory. The shared directory is treated as read-only.
+		std::error_code ec;
+		for (const auto& entry : directory_iterator(getTestDataDir(), ec))
+		{
+			if (!entry.is_regular_file())
+			{
+				continue;
+			}
+			if (!ArchiveExtractor::IsArchiveTypeSupported(entry.path().filename()))
+			{
+				continue;
+			}
+
+			std::filesystem::copy_file(entry.path(), m_scratchDir / entry.path().filename(),
+				std::filesystem::copy_options::overwrite_existing, ec);
+		}
+
+		m_pDesignCache = std::unique_ptr<DesignCache>(new DesignCache(m_scratchDir.string()));
 		ASSERT_NE(m_pDesignCache, nullptr);
 	}
 
 	void FileArchiveLoadFixture::TearDown()
 	{
-		if (m_removeDecompressedDirectories)
+		// Remove only this fixture's isolated scratch dir; never touch the shared
+		// test-data directory (doing so raced with concurrent test processes).
+		if (!m_scratchDir.empty())
 		{
-			if (exists(getTestDataDir()))
-			{
-				// delete uncompressed directories
-				for (const auto& entry : directory_iterator(getTestDataDir()))
-				{
-					if (is_directory(entry))
-					{
-						if (std::find(KEEP_DIRECTORIES.begin(), KEEP_DIRECTORIES.end(), entry.path().filename()) == KEEP_DIRECTORIES.end())
-						{
-							remove_all(entry.path());
-						}
-					}
-				}
-			}
+			std::error_code ec;
+			std::filesystem::remove_all(m_scratchDir, ec);
 		}
 
 		TestDataFixture::TearDown();
-	}	
+	}
 
 	path FileArchiveLoadFixture::getDesignPath(const std::string& filename) const
 	{
 		return getTestDataDir() / filename;
+	}
+
+	path FileArchiveLoadFixture::getIsolatedDesignPath(const std::string& filename) const
+	{
+		return m_scratchDir / filename;
 	}
 }

--- a/OdbDesignTests/Fixtures/FileArchiveLoadFixture.cpp
+++ b/OdbDesignTests/Fixtures/FileArchiveLoadFixture.cpp
@@ -42,7 +42,11 @@ namespace
 			// create_directory atomically succeeds only if the dir does not yet exist.
 			if (std::filesystem::create_directory(candidate, ec))
 			{
-				return candidate;
+				// Resolve any symlinks in the system temp path (e.g. macOS /var ->
+				// /private/var) so libarchive's ARCHIVE_EXTRACT_SECURE_SYMLINKS check
+				// does not refuse to extract into the scratch directory.
+				auto resolved = std::filesystem::weakly_canonical(candidate, ec);
+				return ec ? candidate : resolved;
 			}
 		}
 	}

--- a/OdbDesignTests/Fixtures/FileArchiveLoadFixture.cpp
+++ b/OdbDesignTests/Fixtures/FileArchiveLoadFixture.cpp
@@ -11,6 +11,7 @@
 #include <atomic>
 #include <sstream>
 #include <system_error>
+#include <stdexcept>
 #include <cstdint>
 
 using namespace std::filesystem;
@@ -27,19 +28,27 @@ namespace
 		std::error_code ec;
 		auto base = std::filesystem::temp_directory_path() / "odbdesign_tests";
 		std::filesystem::create_directories(base, ec);
+		if (ec)
+		{
+			throw std::runtime_error("failed to create scratch base dir '" + base.string() + "': " + ec.message());
+		}
 
 		static std::atomic<uint64_t> counter{ 0 };
 		std::random_device rd;
 		std::mt19937_64 gen((static_cast<uint64_t>(rd()) << 32) ^ rd());
 		std::uniform_int_distribution<uint64_t> dist;
 
-		for (;;)
+		// Bounded retry: create_directory atomically succeeds only if the dir does not
+		// yet exist. Collisions are astronomically unlikely (64-bit random + atomic
+		// counter), but a bound makes the failure mode explicit rather than spinning
+		// forever if the filesystem is in a pathological state.
+		constexpr int kMaxAttempts = 100;
+		for (int attempt = 0; attempt < kMaxAttempts; ++attempt)
 		{
 			std::ostringstream name;
 			name << std::hex << dist(gen) << "_" << std::hex << counter.fetch_add(1);
 
 			auto candidate = base / name.str();
-			// create_directory atomically succeeds only if the dir does not yet exist.
 			if (std::filesystem::create_directory(candidate, ec))
 			{
 				// Resolve any symlinks in the system temp path (e.g. macOS /var ->
@@ -49,6 +58,8 @@ namespace
 				return ec ? candidate : resolved;
 			}
 		}
+
+		throw std::runtime_error("failed to create a unique scratch dir after " + std::to_string(kMaxAttempts) + " attempts");
 	}
 }
 
@@ -82,6 +93,10 @@ namespace Odb::Test::Fixtures
 
 			std::filesystem::copy_file(entry.path(), m_scratchDir / entry.path().filename(),
 				std::filesystem::copy_options::overwrite_existing, ec);
+			// Fail loudly if an archive failed to copy, otherwise the DesignCache is
+			// pointed at a scratch dir missing the archive and the test later fails
+			// with an opaque parse error rather than a clear setup failure.
+			ASSERT_FALSE(ec) << "copy_file failed for '" << entry.path() << "': " << ec.message();
 		}
 
 		m_pDesignCache = std::unique_ptr<DesignCache>(new DesignCache(m_scratchDir.string()));

--- a/OdbDesignTests/Fixtures/FileArchiveLoadFixture.h
+++ b/OdbDesignTests/Fixtures/FileArchiveLoadFixture.h
@@ -15,15 +15,21 @@ namespace Odb::Test::Fixtures
 
 	protected:
 		std::unique_ptr<Odb::Lib::App::DesignCache> m_pDesignCache;
-		
-		const bool m_removeDecompressedDirectories = true;
+
+		// Per-fixture isolated directory: design archives are copied here and extracted
+		// within it, so concurrent test processes never share a mutable on-disk location.
+		std::filesystem::path m_scratchDir;
 
 		void SetUp() override;
 		void TearDown() override;
 
 		std::filesystem::path getDesignPath(const std::string& filename) const;
-			
-		static inline const std::vector<std::string> KEEP_DIRECTORIES = { TESTDATA_FILES_DIR };		
+
+		// Returns the path to a per-fixture isolated copy of a design archive.
+		// Use this (instead of getDesignPath) when a test extracts/parses an archive
+		// directly, so extraction lands in the per-fixture scratch dir rather than the
+		// shared test-data directory (keeps parallel test runs from racing on disk).
+		std::filesystem::path getIsolatedDesignPath(const std::string& filename) const;
 
 	};
 }

--- a/OdbDesignTests/Fixtures/FileArchiveLoadFixture.h
+++ b/OdbDesignTests/Fixtures/FileArchiveLoadFixture.h
@@ -23,6 +23,11 @@ namespace Odb::Test::Fixtures
 		void SetUp() override;
 		void TearDown() override;
 
+		// Returns the path to the archive under the SHARED, read-only TEST_DATA dir.
+		// Safe only for read-only access (existence/file_size checks). For any test that
+		// extracts or parses an archive in place, use getIsolatedDesignPath() instead so
+		// extraction lands in the per-fixture scratch dir rather than mutating the shared
+		// test-data directory (which races under ctest -j).
 		std::filesystem::path getDesignPath(const std::string& filename) const;
 
 		// Returns the path to a per-fixture isolated copy of a design archive.

--- a/docs/one_pager.md
+++ b/docs/one_pager.md
@@ -1,0 +1,25 @@
+### **Purpose and Core Capabilities**
+
+**OdbDesign** is a free, open-source, cross-platform C++ library specifically designed to parse ODB++ Design archives. Its core capability lies in extracting complex data from these archives and using it to build comprehensive net list product models. It serves as a bridge, allowing applications to programmatically access and utilize ODB++ printed circuit board (PCB) design data.
+
+### **Key Features**
+
+* **High Performance:** Written in C++ and compiled into native code, the parser avoids the overhead of interpreters or virtual machines. It is also multi-threaded to fully leverage modern multi-core CPUs for fast processing.  
+* **Cross-Platform Flexibility:** The core library runs natively on Windows, Linux, and macOS. Additionally, its Dockerized version ensures it can run on virtually any platform or Kubernetes cluster.  
+* **Robust Security:** The project maintains a high OpenSSF Security Scorecard rating (7.8). It is built using the latest C++ standards and compilers, and all code, dependencies, and Docker images undergo rigorous automated security scanning.  
+* **Domain Expertise:** The library is maintained by a developer with over a decade of specialized experience in the PCB manufacturing hardware industry, ensuring the parser is highly efficient and aligned with industry standards.
+
+### **Primary Utility for Engineers**
+
+For engineers and developers working with PCB manufacturing, ODB++ archives contain critical, dense design data. OdbDesign simplifies the extraction of this data. Instead of writing custom parsers from scratch to decode the proprietary-style ODB++ format, engineers can use this library to instantly access parsed data and net list models. This accelerates the development of Electronic Design Automation (EDA), Design for Manufacturing (DFM), and PCB viewing tools.
+
+>*The project operates under the strict [AGPL V3.0 license](https://www.gnu.org/licenses/agpl-3.0.en.html), which is a copy-left license. Use in closed-source commercial applications **requires** contacting the author to obtain a separate commercial license, while open-source projects can use the library freely under the AGPL V3.0 terms.*
+
+### **How the REST API Integration Works**
+
+The library isn't just for C++ developers; its REST API makes the data universally accessible.
+
+* **Language Agnostic:** Because the parsed data is exposed via standard REST and gRPC APIs, developers can query the ODB++ data using any programming language (Python, JavaScript, Rust, etc.).  
+* **Containerized Deployment:** The REST API server is packaged inside a ready-to-deploy Docker image, making it trivial to spin up locally using Docker Compose or deploy onto scalable Kubernetes (k8s) clusters.  
+* **Decoupled Architecture:** The architecture allows you to run the heavy, multi-threaded C++ parser on a high-performance server or workstation.  
+* **Lightweight Client Access:** Because the heavy lifting is done server-side, low-power devices—such as mobile phones, web browsers, or Raspberry Pis—can easily request and consume the parsed ODB++ data over the network without needing substantial local processing power.


### PR DESCRIPTION
Give each FileArchiveLoadFixture instance an isolated per-process scratch directory under the system temp dir, copy the design archives into it, and point the DesignCache there so extraction no longer writes into the shared TEST_DATA directory. TearDown now removes only that scratch dir instead of delete-all non-FILES dirs, which raced under ctest -j.

Also redirect the archive-compression test outputs to the temp dir so they stop leaving artifacts in TEST_DATA. Windows-portable (copy, not symlink). Serial and parallel (-j) suites both pass 129/129.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>