### PR TITLE
fix(cache): surface corrupt designs as errors, not NOT_FOUND

### DIFF
--- a/OdbDesignLib/App/DesignCache.cpp
+++ b/OdbDesignLib/App/DesignCache.cpp
@@ -3,6 +3,7 @@
 #include "Logger.h"
 #include <exception>
 #include <filesystem>
+#include <stdexcept>
 #include <vector>
 #include "../FileModel/Design/FileArchive.h"
 #include <memory>
@@ -395,10 +396,14 @@ namespace Odb::Lib::App
                     {
                         return pFileArchive;
                     }
-                    else
-                    {
-                        break;
-                    }
+
+                    // A matching file was found but failed to extract or parse. Treat this
+                    // as a corrupt/unloadable design (error) rather than a missing one, so
+                    // callers surface INTERNAL/500 instead of a misleading NOT_FOUND/404.
+                    // (ParseFileModel already throws on parse failure; this covers the
+                    // extraction / missing-root-dir paths that return false.)
+                    throw std::runtime_error(
+                        "Failed to load design \"" + designName + "\" from \"" + entry.path().string() + "\"");
                 }
             }
         }       

--- a/OdbDesignLib/App/DesignCache.cpp
+++ b/OdbDesignLib/App/DesignCache.cpp
@@ -402,8 +402,10 @@ namespace Odb::Lib::App
                     // callers surface INTERNAL/500 instead of a misleading NOT_FOUND/404.
                     // (ParseFileModel already throws on parse failure; this covers the
                     // extraction / missing-root-dir paths that return false.)
+                    // The file path is intentionally omitted here to avoid leaking server
+                    // filesystem details to API clients (it is logged above for diagnostics).
                     throw std::runtime_error(
-                        "Failed to load design \"" + designName + "\" from \"" + entry.path().string() + "\"");
+                        "Failed to load design \"" + designName + "\": could not extract or parse archive");
                 }
             }
         }       

--- a/OdbDesignTests/DesignCacheLoadTests.cpp
+++ b/OdbDesignTests/DesignCacheLoadTests.cpp
@@ -2,10 +2,35 @@
 #include "Fixtures/FileArchiveLoadFixture.h"
 #include "OdbDesign.h"
 
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+#include "ArchiveExtractor.h"
+
 //using namespace Odb::Lib::App;
 using namespace Odb::Lib::FileModel;
 using namespace Odb::Test::Fixtures;
 using namespace std::filesystem;
+
+namespace
+{
+	// Isolated, symlink-resolved temp directory so libarchive extraction works
+	// on macOS (where temp_directory_path() begins with /var -> /private/var).
+	std::filesystem::path makeUniqueCacheDir()
+	{
+		std::error_code ec;
+		const auto tempDir = std::filesystem::weakly_canonical(std::filesystem::temp_directory_path(ec), ec);
+		const auto base = (ec ? std::filesystem::temp_directory_path() : tempDir) / "odb_designcache_loadtests";
+		std::filesystem::create_directories(base, ec);
+		std::random_device rd;
+		return base / (std::to_string(rd()) + "_" + std::to_string(rd()));
+	}
+}
 
 namespace Odb::Test
 {
@@ -21,5 +46,74 @@ namespace Odb::Test
 		//ASSERT_TRUE(exists(getDesignPath("designodb_rigidflex.tgz")));
 		auto pDesign = m_pDesignCache->GetDesign("designodb_rigidflex");
 		ASSERT_NE(pDesign, nullptr);
-	}	
+	}
+
+	// A present-but-unextractable archive must surface as an error (throw),
+	// not a misleading nullptr that maps to NOT_FOUND/404.
+	TEST(DesignCacheLoadError, ThrowsForUnextractableArchive)
+	{
+		const auto cacheDir = makeUniqueCacheDir();
+		std::error_code ec;
+		std::filesystem::create_directories(cacheDir, ec);
+		ASSERT_FALSE(ec) << ec.message();
+
+		// Garbage bytes that look like an archive by filename but cannot extract.
+		const auto archivePath = cacheDir / "broken.tgz";
+		{
+			std::ofstream out(archivePath, std::ios::binary);
+			out << "this is not a valid archive";
+		}
+
+		Odb::Lib::App::DesignCache cache(cacheDir.string());
+		EXPECT_THROW(cache.GetFileArchive("broken"), std::exception);
+
+		std::filesystem::remove_all(cacheDir, ec);
+	}
+
+	// A valid archive that extracts but fails to parse must also throw
+	// (ParseFileModel already throws on parse failure; this guards the contract).
+	TEST(DesignCacheLoadError, ThrowsForUnparseableArchive)
+	{
+		const auto cacheDir = makeUniqueCacheDir();
+		std::error_code ec;
+		std::filesystem::create_directories(cacheDir, ec);
+		ASSERT_FALSE(ec) << ec.message();
+
+		// Valid tgz with the required top-level dirs but empty, so it extracts
+		// but ParseDesignDirectory fails.
+		auto srcRoot = cacheDir / "src" / "bad_design";
+		for (const auto* sub : { "fonts", "misc", "matrix", "steps" })
+		{
+			std::filesystem::create_directories(srcRoot / sub, ec);
+			ASSERT_FALSE(ec) << ec.message();
+		}
+
+		std::string createdArchivePath;
+		ASSERT_TRUE(::Utils::ArchiveExtractor::CompressDir(
+			srcRoot.string(), cacheDir.string(), "bad_design", createdArchivePath));
+		ASSERT_FALSE(createdArchivePath.empty());
+
+		Odb::Lib::App::DesignCache cache(cacheDir.string());
+		EXPECT_THROW(cache.GetFileArchive("bad_design"), std::exception);
+
+		std::filesystem::remove_all(cacheDir, ec);
+	}
+
+	// A genuinely absent design must still return nullptr (no throw), so callers
+	// can keep mapping it to NOT_FOUND.
+	TEST(DesignCacheLoadError, ReturnsNullptrForMissingDesign)
+	{
+		const auto cacheDir = makeUniqueCacheDir();
+		std::error_code ec;
+		std::filesystem::create_directories(cacheDir, ec);
+		ASSERT_FALSE(ec) << ec.message();
+
+		Odb::Lib::App::DesignCache cache(cacheDir.string());
+		EXPECT_NO_THROW({
+			auto p = cache.GetFileArchive("does_not_exist");
+			EXPECT_EQ(p, nullptr);
+		});
+
+		std::filesystem::remove_all(cacheDir, ec);
+	}
 }

--- a/OdbDesignTests/DesignCacheLoadTests.cpp
+++ b/OdbDesignTests/DesignCacheLoadTests.cpp
@@ -30,6 +30,14 @@ namespace
 		std::random_device rd;
 		return base / (std::to_string(rd()) + "_" + std::to_string(rd()));
 	}
+
+	// Removes the temp dir on destruction, so cleanup still runs when an ASSERT_*
+	// fails partway through a test (ASSERT returns from the test body).
+	struct TempDirGuard
+	{
+		std::filesystem::path path;
+		~TempDirGuard() { std::error_code ec; std::filesystem::remove_all(path, ec); }
+	};
 }
 
 namespace Odb::Test
@@ -53,6 +61,7 @@ namespace Odb::Test
 	TEST(DesignCacheLoadError, ThrowsForUnextractableArchive)
 	{
 		const auto cacheDir = makeUniqueCacheDir();
+		TempDirGuard guard{cacheDir};
 		std::error_code ec;
 		std::filesystem::create_directories(cacheDir, ec);
 		ASSERT_FALSE(ec) << ec.message();
@@ -66,8 +75,6 @@ namespace Odb::Test
 
 		Odb::Lib::App::DesignCache cache(cacheDir.string());
 		EXPECT_THROW(cache.GetFileArchive("broken"), std::exception);
-
-		std::filesystem::remove_all(cacheDir, ec);
 	}
 
 	// A valid archive that extracts but fails to parse must also throw
@@ -75,6 +82,7 @@ namespace Odb::Test
 	TEST(DesignCacheLoadError, ThrowsForUnparseableArchive)
 	{
 		const auto cacheDir = makeUniqueCacheDir();
+		TempDirGuard guard{cacheDir};
 		std::error_code ec;
 		std::filesystem::create_directories(cacheDir, ec);
 		ASSERT_FALSE(ec) << ec.message();
@@ -95,8 +103,6 @@ namespace Odb::Test
 
 		Odb::Lib::App::DesignCache cache(cacheDir.string());
 		EXPECT_THROW(cache.GetFileArchive("bad_design"), std::exception);
-
-		std::filesystem::remove_all(cacheDir, ec);
 	}
 
 	// A genuinely absent design must still return nullptr (no throw), so callers
@@ -104,6 +110,7 @@ namespace Odb::Test
 	TEST(DesignCacheLoadError, ReturnsNullptrForMissingDesign)
 	{
 		const auto cacheDir = makeUniqueCacheDir();
+		TempDirGuard guard{cacheDir};
 		std::error_code ec;
 		std::filesystem::create_directories(cacheDir, ec);
 		ASSERT_FALSE(ec) << ec.message();
@@ -113,7 +120,5 @@ namespace Odb::Test
 			auto p = cache.GetFileArchive("does_not_exist");
 			EXPECT_EQ(p, nullptr);
 		});
-
-		std::filesystem::remove_all(cacheDir, ec);
 	}
 }


### PR DESCRIPTION
## Problem

`DesignCache::LoadFileArchive` returned `nullptr` for **both** "design name does not exist" and "design file found but failed to extract/parse". Parse failure already threw (`ParseFileModel` throws `runtime_error("Parsing failed.")`), but the **extraction / missing-root-dir** paths returned `false`, which `LoadFileArchive` turned into `nullptr`.

Net effect: a **present-but-broken** design mapped to `NOT_FOUND`/404 at the API — indistinguishable from a design that simply is not there. (This surfaced during PR #556/#557 review: an unparseable archive returned INTERNAL only if it failed at parse; if it failed at extraction it slipped through as NOT_FOUND.)

## Fix

When a matching file is found but fails to load, `LoadFileArchive` now **throws** so the error propagates. Genuinely absent designs still return `nullptr`.

| Scenario | Before | After |
|----------|--------|-------|
| Design absent | `nullptr` → NOT_FOUND/404 | `nullptr` → NOT_FOUND/404 (unchanged) |
| Present, fails to extract | `nullptr` → NOT_FOUND/404 ❌ | throws → INTERNAL/500 ✅ |
| Present, fails to parse | throws → INTERNAL/500 | throws → INTERNAL/500 (unchanged) |

## Caller safety

`GetFileArchive`/`GetDesign` are chokepoints, but all callers already handle exceptions:
- **gRPC services** (`GetDesign`/`GetLayerSymbols`/`GetStandardFonts`): `try/catch` → `INTERNAL`.
- **Batch loaders** (`loadAllFileArchives`, `loadFileArchives`, `loadDesigns`…): already `try/catch` (respect `stopOnError`).
- **`SaveFileArchive`**: only called after `AddFileArchive` caches the archive, so its `GetFileArchive` hits the fast path — no throw.
- **REST controllers** (`FileModelController`, `DesignsController`): exception escapes to Crow → **500**. Corrupt-design responses change 404 → 500 (more accurate; accepted behavior change).

## Tests

`DesignCacheLoadTests.cpp`:
- `ThrowsForUnextractableArchive` — garbage-bytes archive → throws (new path).
- `ThrowsForUnparseableArchive` — valid tgz, empty top-level dirs → throws (existing path).
- `ReturnsNullptrForMissingDesign` — absent design → `nullptr`, no throw.

Full suite: **128/128 pass** (system `ctest`, no regressions).

## Out of scope
- No REST controller edits (Crow default 500 is sufficient).
- Not bundled with #556 / #557; this is an independent core-cache change.