### PR TITLE
build(linux): roll out linux-dynamic-release as the main Linux preset

### DIFF
--- a/.ai-repo-summary.md
+++ b/.ai-repo-summary.md
@@ -53,8 +53,8 @@ Linux (bash)
 - Automated dependency install (Ubuntu/Debian/Mint):
   - `./scripts/install-dependencies-deb.sh`
 - Configure & build (Release):
-  - `cmake --preset linux-release`
-  - `cmake --build --preset linux-release`
+  - `cmake --preset linux-dynamic-release`
+  - `cmake --build --preset linux-dynamic-release`
 - Configure & build (Debug):
   - `cmake --preset linux-debug`
   - `cmake --build --preset linux-debug`
@@ -79,17 +79,17 @@ Notes/gotchas
 ## Test
 - Tests are GoogleTest-based (`OdbDesignTests`). Build with your chosen preset then run tests.
 - Run with CTest against the build tree:
-  - Linux (bash): `ctest --test-dir ./out/build/linux-release --output-on-failure`
+  - Linux (bash): `ctest --test-dir ./out/build/linux-dynamic-release --output-on-failure`
   - Windows (PowerShell): `ctest --test-dir .\out\build\x64-release --output-on-failure`
 - Note: Some tests may require local test data; without it, a subset may fail.
 
 ## Run
 CLI app
-- After building, run `OdbDesignApp` from your build output folder (e.g., `./out/build/linux-release/OdbDesignApp/OdbDesignApp --help`).
+- After building, run `OdbDesignApp` from your build output folder (e.g., `./out/build/linux-dynamic-release/OdbDesignApp/OdbDesignApp --help`).
 
 Server
 - After building, run `OdbDesignServer` from your build output folder.
-  - Linux: `./out/build/linux-release/OdbDesignServer/OdbDesignServer --help` then `--port 8888`
+  - Linux: `./out/build/linux-dynamic-release/OdbDesignServer/OdbDesignServer --help` then `--port 8888`
 - Endpoints/controllers include: HelloWorld, FileUpload, FileModel, HealthCheck, Designs.
 - The server uses Crow; enable SSL and compression via compile defs (`CROW_ENABLE_SSL`, `CROW_ENABLE_COMPRESSION`). Provide certs/keys as configured in the app if enabling TLS. If you encounter runtime issues, smoke test with `--help` first.
 
@@ -110,7 +110,7 @@ Docker
 - vcpkg network failures: install `libarchive-dev` via apt as a fallback; then `vcpkg install --keep-going`.
 - Protobuf compilation errors: regenerate via the vcpkg protoc:
   - `cd OdbDesignLib/protoc`
-  - `$VCPKG_ROOT/../out/build/linux-release/vcpkg_installed/x64-linux/tools/protobuf/protoc --cpp_out=../ProtoBuf *.proto`
+  - `$VCPKG_ROOT/../out/build/linux-dynamic-release/vcpkg_installed/x64-linux/tools/protobuf/protoc --cpp_out=../ProtoBuf *.proto`
 - Precompiled headers (PCH) issues: temporarily disable PCH in CMake if needed by editing the guard around `target_precompile_headers`.
 
 ## Where to make changes
@@ -134,7 +134,7 @@ docs/BUILD.md                   # Detailed build instructions
 
 ## Build output locations
 ```
-out/build/linux-release/       # Linux release build
+out/build/linux-dynamic-release/ # Linux release build (shared protobuf/gRPC)
 out/build/linux-debug/         # Linux debug build
 out/build/x64-release/         # Windows release build
 ```

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -253,7 +253,7 @@ jobs:
       - name: Manual vcpkg Install (Linux)
         # match the linux-dynamic-release preset's triplet
         run: '"${{env.VCPKG_ROOT}}/vcpkg" install --triplet x64-linux-dynamic'
-        if: matrix.os == 'ubuntu-24.04' && matrix.preset != 'linux-mingw-w64-release'
+        if: matrix.preset == 'linux-dynamic-release'
 
       - name: Manual vcpkg Install (macOS)
         run: '"${{env.VCPKG_ROOT}}/vcpkg" install'
@@ -314,9 +314,14 @@ jobs:
           cp ./out/build/${{matrix.preset}}/OdbDesignServer/OdbDesignServer ${{env.ARTIFACTS_DIR}}
           # vcpkg shared libraries (protobuf, gRPC, ...) required at runtime by
           # the linux-dynamic-release build; Dockerfile.prebuilt copies *.so*
-          cp ./out/build/${{matrix.preset}}/vcpkg_installed/x64-linux-dynamic/lib/*.so* ${{env.ARTIFACTS_DIR}}
+          # -P preserves vcpkg's dev symlinks (libfoo.so -> libfoo.so.N -> real
+          # file) so each lib ships once; zip -y below stores them as links
+          cp -P ./out/build/${{matrix.preset}}/vcpkg_installed/x64-linux-dynamic/lib/*.so* ${{env.ARTIFACTS_DIR}}
+          # OpenSSL 3 provider modules (resolved relative to libcrypto.so's dir);
+          # mirrors the full Dockerfile's ossl-modules COPY
+          cp -r ./out/build/${{matrix.preset}}/vcpkg_installed/x64-linux-dynamic/lib/ossl-modules ${{env.ARTIFACTS_DIR}}/
           cd ${{env.ARTIFACTS_DIR}}
-          zip -r -y ./artifacts-${{matrix.os}}.zip ./*.so* ./OdbDesignServer
+          zip -r -y ./artifacts-${{matrix.os}}.zip ./*.so* ./ossl-modules ./OdbDesignServer
 
       - name: Compress Artifacts (MacOS)
         if: matrix.os == 'macos-14'

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -56,8 +56,11 @@ jobs:
           - os: windows-2022
             preset: x64-release
           # Linux x64 Release (upgraded to 24.04 for newer toolchain)
+          # dynamic triplet: shared protobuf/gRPC runtime — the static
+          # linux-release preset loads two protobuf copies and crashes
+          # (see docs/linux-dynamic-release-plan.md)
           - os: ubuntu-24.04
-            preset: linux-release
+            preset: linux-dynamic-release
           # MacOS x64 Release
           - os: macos-14
             preset: macos-release
@@ -247,9 +250,14 @@ jobs:
       #     ./scripts/generate-python-module.sh
       #   if: matrix.preset == 'python-linux-release'
 
-      - name: Manual vcpkg Install (Non-Windows)
+      - name: Manual vcpkg Install (Linux)
+        # match the linux-dynamic-release preset's triplet
+        run: '"${{env.VCPKG_ROOT}}/vcpkg" install --triplet x64-linux-dynamic'
+        if: matrix.os == 'ubuntu-24.04' && matrix.preset != 'linux-mingw-w64-release'
+
+      - name: Manual vcpkg Install (macOS)
         run: '"${{env.VCPKG_ROOT}}/vcpkg" install'
-        if: matrix.preset != 'linux-mingw-w64-release' && matrix.os != 'windows-2022'
+        if: matrix.os == 'macos-14'
 
       - name: Manual vcpkg Install (Windows)
         run: '& "${{env.VCPKG_ROOT}}/vcpkg" install --triplet x64-windows'
@@ -304,8 +312,11 @@ jobs:
           cp ./out/build/${{matrix.preset}}/OdbDesignLib/*.so ${{env.ARTIFACTS_DIR}}
           cp ./out/build/${{matrix.preset}}/Utils/*.so ${{env.ARTIFACTS_DIR}}
           cp ./out/build/${{matrix.preset}}/OdbDesignServer/OdbDesignServer ${{env.ARTIFACTS_DIR}}
+          # vcpkg shared libraries (protobuf, gRPC, ...) required at runtime by
+          # the linux-dynamic-release build; Dockerfile.prebuilt copies *.so*
+          cp ./out/build/${{matrix.preset}}/vcpkg_installed/x64-linux-dynamic/lib/*.so* ${{env.ARTIFACTS_DIR}}
           cd ${{env.ARTIFACTS_DIR}}
-          zip -r ./artifacts-${{matrix.os}}.zip ./*.so ./OdbDesignServer
+          zip -r -y ./artifacts-${{matrix.os}}.zip ./*.so* ./OdbDesignServer
 
       - name: Compress Artifacts (MacOS)
         if: matrix.os == 'macos-14'

--- a/.github/workflows/disabled/codeql.yml
+++ b/.github/workflows/disabled/codeql.yml
@@ -133,7 +133,8 @@ jobs:
               core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
         - name: vcpkg Install Dependencies
-          run: "\"${{env.VCPKG_ROOT}}/vcpkg\" install"
+          # match the matrix's linux-dynamic-release preset triplet
+          run: "\"${{env.VCPKG_ROOT}}/vcpkg\" install --triplet x64-linux-dynamic"
 
         - name: CMake Configure
           run: cmake --preset ${{ matrix.preset }}

--- a/.github/workflows/disabled/codeql.yml
+++ b/.github/workflows/disabled/codeql.yml
@@ -68,7 +68,8 @@ jobs:
         include:
           - language: 'c-cpp'
             os: 'ubuntu-24.04'
-            preset: 'linux-release'          
+            # dynamic triplet: shared protobuf/gRPC runtime (see docs/linux-dynamic-release-plan.md)
+            preset: 'linux-dynamic-release'          
           # Uncomment to add Windows analysis
           # - language: 'c-cpp'
           #   os: 'windows-2022'

--- a/.github/workflows/disabled/test-runtime.yml
+++ b/.github/workflows/disabled/test-runtime.yml
@@ -38,9 +38,9 @@ jobs:
           # Windows x64 Release
           - os: windows-2022
             preset: x64-release
-          # Linux x64 Release          
+          # Linux x64 Release (dynamic triplet: shared protobuf/gRPC runtime)
           - os: ubuntu-24.04
-            preset: linux-release
+            preset: linux-dynamic-release
           # MacOS x64 Release
           - os: macos-12
             preset: macos-release

--- a/.github/workflows/vcpkg-cache-warm.yml
+++ b/.github/workflows/vcpkg-cache-warm.yml
@@ -123,8 +123,13 @@ jobs:
       - name: Install Ninja
         uses: seanmiddleditch/gha-setup-ninja@8b297075da4cd2a5f1fd21fe011b499edf06e9d2 # master
 
-      - name: Warm vcpkg Binary Cache
+      - name: Warm vcpkg Binary Cache (static triplet)
+        # still consumed by code-coverage.yml (linux-debug preset)
         run: '"${{ env.VCPKG_ROOT }}/vcpkg" install'
+
+      - name: Warm vcpkg Binary Cache (dynamic triplet)
+        # consumed by the linux-dynamic-release preset (cmake-multi-platform, Dockerfile)
+        run: '"${{ env.VCPKG_ROOT }}/vcpkg" install --triplet x64-linux-dynamic'
 
   warm-macos:
     name: Vcpkg-Cache-Warm (macOS)

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ gpg_keys/
 # IDE state / editor backups
 /.idea/
 /docs/plan/*.old
+.qwen/tmp/s-954746f9-a168-43ee-b954-e8e97a725965/qwen-skill-args-resolve-pr-comments.txt
+.qwen/tmp/s-d05672ef-b4f4-4a7f-97fc-df1f46868b32/qwen-skill-args-resolve-pr-comments.txt

--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,5 @@ gpg_keys/
 # IDE state / editor backups
 /.idea/
 /docs/plan/*.old
-.qwen/tmp/s-954746f9-a168-43ee-b954-e8e97a725965/qwen-skill-args-resolve-pr-comments.txt
-.qwen/tmp/s-d05672ef-b4f4-4a7f-97fc-df1f46868b32/qwen-skill-args-resolve-pr-comments.txt
+# Qwen Code session scratch (per-session s-<uuid> dirs) — disposable
+.qwen/tmp/

--- a/.vscode/codeql-settings.json
+++ b/.vscode/codeql-settings.json
@@ -3,7 +3,7 @@
   "database": {
     "languages": ["cpp"],
     "sourceRoot": ".",
-    "buildCommand": "cmake --preset linux-release && cmake --build --preset linux-release"
+    "buildCommand": "cmake --preset linux-dynamic-release && cmake --build --preset linux-dynamic-release"
   },
   "queries": {
     "suites": [

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -11,7 +11,7 @@
   },
   {
     "label": "CMake: Configure (Linux Release)",
-    "command": "cmake --preset linux-release",
+    "command": "cmake --preset linux-dynamic-release",
     "cwd": "$ZED_WORKTREE_ROOT",
     "use_new_terminal": false,
     "allow_concurrent_runs": false,
@@ -21,15 +21,6 @@
   {
     "label": "CMake: Configure (Linux Dynamic Debug)",
     "command": "cmake --preset linux-dynamic-debug",
-    "cwd": "$ZED_WORKTREE_ROOT",
-    "use_new_terminal": false,
-    "allow_concurrent_runs": false,
-    "reveal": "always",
-    "hide": "on_success"
-  },
-  {
-    "label": "CMake: Configure (Linux Dynamic Release)",
-    "command": "cmake --preset linux-dynamic-release",
     "cwd": "$ZED_WORKTREE_ROOT",
     "use_new_terminal": false,
     "allow_concurrent_runs": false,
@@ -49,7 +40,7 @@
   },
   {
     "label": "CMake: Build (Linux Release)",
-    "command": "cmake --build --preset linux-release",
+    "command": "cmake --build --preset linux-dynamic-release",
     "cwd": "$ZED_WORKTREE_ROOT",
     "use_new_terminal": false,
     "allow_concurrent_runs": false,
@@ -59,15 +50,6 @@
   {
     "label": "CMake: Build (Linux Dynamic Debug)",
     "command": "cmake --build --preset linux-dynamic-debug",
-    "cwd": "$ZED_WORKTREE_ROOT",
-    "use_new_terminal": false,
-    "allow_concurrent_runs": false,
-    "reveal": "always",
-    "hide": "on_success"
-  },
-  {
-    "label": "CMake: Build (Linux Dynamic Release)",
-    "command": "cmake --build --preset linux-dynamic-release",
     "cwd": "$ZED_WORKTREE_ROOT",
     "use_new_terminal": false,
     "allow_concurrent_runs": false,
@@ -87,7 +69,7 @@
   },
   {
     "label": "CMake: Test (Linux Release)",
-    "command": "ctest --preset linux-release --output-on-failure",
+    "command": "ctest --preset linux-dynamic-release --output-on-failure",
     "cwd": "$ZED_WORKTREE_ROOT",
     "use_new_terminal": false,
     "allow_concurrent_runs": false,
@@ -97,15 +79,6 @@
   {
     "label": "CMake: Test (Linux Dynamic Debug)",
     "command": "ctest --preset linux-dynamic-debug --output-on-failure",
-    "cwd": "$ZED_WORKTREE_ROOT",
-    "use_new_terminal": false,
-    "allow_concurrent_runs": false,
-    "reveal": "always",
-    "hide": "never"
-  },
-  {
-    "label": "CMake: Test (Linux Dynamic Release)",
-    "command": "ctest --preset linux-dynamic-release --output-on-failure",
     "cwd": "$ZED_WORKTREE_ROOT",
     "use_new_terminal": false,
     "allow_concurrent_runs": false,
@@ -125,7 +98,7 @@
   },
   {
     "label": "CMake: Clean Build (Linux Release)",
-    "command": "cmake --build --preset linux-release --target clean",
+    "command": "cmake --build --preset linux-dynamic-release --target clean",
     "cwd": "$ZED_WORKTREE_ROOT",
     "use_new_terminal": false,
     "allow_concurrent_runs": false,
@@ -145,7 +118,7 @@
   },
   {
     "label": "CMake: Configure & Build (Linux Release)",
-    "command": "cmake --preset linux-release && cmake --build --preset linux-release",
+    "command": "cmake --preset linux-dynamic-release && cmake --build --preset linux-dynamic-release",
     "cwd": "$ZED_WORKTREE_ROOT",
     "use_new_terminal": false,
     "allow_concurrent_runs": false,
@@ -165,7 +138,7 @@
   },
   {
     "label": "CMake: Build & Test (Linux Release)",
-    "command": "cmake --build --preset linux-release && ctest --preset linux-release --output-on-failure",
+    "command": "cmake --build --preset linux-dynamic-release && ctest --preset linux-dynamic-release --output-on-failure",
     "cwd": "$ZED_WORKTREE_ROOT",
     "use_new_terminal": false,
     "allow_concurrent_runs": false,
@@ -194,7 +167,7 @@
   },
   {
     "label": "Run: OdbDesignServer (Release)",
-    "command": "$ZED_WORKTREE_ROOT/out/build/linux-release/OdbDesignServer/OdbDesignServer",
+    "command": "$ZED_WORKTREE_ROOT/out/build/linux-dynamic-release/OdbDesignServer/OdbDesignServer",
     "cwd": "$ZED_WORKTREE_ROOT",
     "use_new_terminal": true,
     "allow_concurrent_runs": false,
@@ -203,7 +176,7 @@
   },
   {
     "label": "Run: OdbDesignApp (Release)",
-    "command": "$ZED_WORKTREE_ROOT/out/build/linux-release/OdbDesignApp/OdbDesignApp",
+    "command": "$ZED_WORKTREE_ROOT/out/build/linux-dynamic-release/OdbDesignApp/OdbDesignApp",
     "cwd": "$ZED_WORKTREE_ROOT",
     "use_new_terminal": true,
     "allow_concurrent_runs": false,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,8 @@ OdbDesign is a C++ library for parsing and working with ODB++ design files (PCB 
 ### Configure (Linux)
 
 ```bash
-cmake --preset linux-debug      # Debug build
-cmake --preset linux-release    # Release build
+cmake --preset linux-debug             # Debug build
+cmake --preset linux-dynamic-release   # Release build (main Linux release; shared protobuf/gRPC)
 ```
 
 ### Configure (Windows)
@@ -32,7 +32,7 @@ cmake --preset x64-release      # Release build
 
 ```bash
 cmake --build --preset linux-debug
-cmake --build --preset linux-release
+cmake --build --preset linux-dynamic-release
 cmake --build --preset x64-release
 ```
 
@@ -50,7 +50,7 @@ cmake --build --preset linux-debug --clean-first
 
 ```bash
 ctest --preset linux-debug
-ctest --preset linux-release
+ctest --preset linux-dynamic-release
 ctest --preset x64-debug
 ```
 

--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -58,7 +58,10 @@ RUN mkdir --parents /OdbDesign/bin /OdbDesign/templates /OdbDesign/designs
 WORKDIR /OdbDesign
 
 # copy pre-built binaries from artifacts (extracted from zip in workflow)
-COPY ./artifacts/*.so ./bin/
+# *.so* (not *.so): the linux-dynamic-release artifacts bundle versioned vcpkg
+# shared libraries (e.g. libarchive.so.13, libprotobuf.so.33) alongside the
+# project libraries; LD_LIBRARY_PATH=/OdbDesign/bin below makes them findable
+COPY ./artifacts/*.so* ./bin/
 COPY ./artifacts/OdbDesignServer ./bin/
 # gRPC service config (loaded by RunGrpcServer from exeDir/config.json)
 COPY ./OdbDesignServer/config.json ./bin/config.json

--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -60,8 +60,13 @@ WORKDIR /OdbDesign
 # copy pre-built binaries from artifacts (extracted from zip in workflow)
 # *.so* (not *.so): the linux-dynamic-release artifacts bundle versioned vcpkg
 # shared libraries (e.g. libarchive.so.13, libprotobuf.so.33) alongside the
-# project libraries; LD_LIBRARY_PATH=/OdbDesign/bin below makes them findable
+# project libraries; LD_LIBRARY_PATH=/OdbDesign/bin below makes them findable.
+# The zip stores vcpkg's dev symlinks as symlinks (zip -y), so COPY recreates
+# libfoo.so -> libfoo.so.N -> real-file chains as links, not duplicate copies.
 COPY ./artifacts/*.so* ./bin/
+# OpenSSL 3 provider modules (resolved relative to libcrypto.so's directory);
+# mirrors the full Dockerfile's ossl-modules COPY
+COPY ./artifacts/ossl-modules ./bin/ossl-modules
 COPY ./artifacts/OdbDesignServer ./bin/
 # gRPC service config (loaded by RunGrpcServer from exeDir/config.json)
 COPY ./OdbDesignServer/config.json ./bin/config.json

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -98,19 +98,21 @@ $ cmake --build --preset x64-release
 ###### Linux
 
 ```Bash
-$ cmake --preset linux-release
-$ cmake --build --preset linux-release
+$ cmake --preset linux-dynamic-release
+$ cmake --build --preset linux-dynamic-release
 
 ```
+
+>This uses the `linux-dynamic-release` preset, which links vcpkg dependencies (protobuf, gRPC, ...) as shared libraries. Linking them statically (`linux-release` preset) loads two copies of protobuf at runtime and crashes. See [linux-dynamic-release-plan.md](./linux-dynamic-release-plan.md).
 
 This builds the C++ shared library and the REST API server executable. See the [Running the C++ Application](#running-the-c%2b%2b-application) section for more details.
 
 The build output can be found in the following directory:
 
-* `~/src/OdbDesign/out/build/x64-release`                         *(Linux/MacOS)*
+* `~/src/OdbDesign/out/build/linux-dynamic-release`                *(Linux)*
 * `C:\Users\<YourName>\Source\OdbDesign\out\build\x64-release`    *(Windows)*
 
->The `x64-release` directory will be different if you selected a different configuration preset (`x64-release` vs. `x64-debug` or `linux-release` vs. `linux-debug`). The `x64-release` directory will contain the shared library and the server executable. Make sure to copy the dependencies (.dll files on Windows, .so files on Linux, .dylib files on MacOS) to the same directory as the executable if you want to copy it somewhere else.
+>The `x64-release` directory will be different if you selected a different configuration preset (`x64-release` vs. `x64-debug` or `linux-dynamic-release` vs. `linux-debug`). The `x64-release` directory will contain the shared library and the server executable. Make sure to copy the dependencies (.dll files on Windows, .so files on Linux, .dylib files on MacOS) to the same directory as the executable if you want to copy it somewhere else. On Linux, the `linux-dynamic-release` build additionally depends on the vcpkg shared libraries in `out/build/linux-dynamic-release/vcpkg_installed/x64-linux-dynamic/lib` — copy them too (or set `LD_LIBRARY_PATH` to that directory).
 
 #### Docker Image for REST API Server
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -315,19 +315,21 @@ $ cmake --build --preset x64-release
 ###### Linux
 
 ```Bash
-$ cmake --preset linux-release
-$ cmake --build --preset linux-release
+$ cmake --preset linux-dynamic-release
+$ cmake --build --preset linux-dynamic-release
 
 ```
+
+>This uses the `linux-dynamic-release` preset, which links vcpkg dependencies (protobuf, gRPC, ...) as shared libraries. Linking them statically (`linux-release` preset) loads two copies of protobuf at runtime and crashes. See [linux-dynamic-release-plan.md](./linux-dynamic-release-plan.md).
 
 This builds the C++ shared library and the REST API server executable. See the [Running the C++ Application](#running-the-c%2b%2b-application) section for more details.
 
 The build output can be found in the following directory:
 
-* `~/src/OdbDesign/out/build/x64-release`                         *(Linux/MacOS)*
+* `~/src/OdbDesign/out/build/linux-dynamic-release`                *(Linux)*
 * `C:\Users\<YourName>\Source\OdbDesign\out\build\x64-release`    *(Windows)*
 
->The `x64-release` directory will be different if you selected a different configuration preset (`x64-release` vs. `x64-debug` or `linux-release` vs. `linux-debug`). The `x64-release` directory will contain the shared library and the server executable. Make sure to copy the dependencies (.dll files on Windows, .so files on Linux, .dylib files on MacOS) to the same directory as the executable if you want to copy it somewhere else.
+>The `x64-release` directory will be different if you selected a different configuration preset (`x64-release` vs. `x64-debug` or `linux-dynamic-release` vs. `linux-debug`). The `x64-release` directory will contain the shared library and the server executable. Make sure to copy the dependencies (.dll files on Windows, .so files on Linux, .dylib files on MacOS) to the same directory as the executable if you want to copy it somewhere else. On Linux, the `linux-dynamic-release` build additionally depends on the vcpkg shared libraries in `out/build/linux-dynamic-release/vcpkg_installed/x64-linux-dynamic/lib` — copy them too (or set `LD_LIBRARY_PATH` to that directory).
 
 #### Docker Image for REST API Server
 

--- a/docs/linux-dynamic-release-plan-prompt.md
+++ b/docs/linux-dynamic-release-plan-prompt.md
@@ -1,0 +1,37 @@
+# linux-dynamic-release-plan
+
+## Objective
+
+The goal is to replace the current `linux-release` preset and binaries with the new `linux-dynamic-release` preset and binaries.
+
+## Background
+
+We discovered that the current derfault/main Cmake preset on linux, `linux-release` as fatal flaw bc it links protobuf lib statically which cause two copied to be loaded at runtime which leads to derenferencing uninitialized pointers and crashed. The new preset `linux-dynamic-release` links the library as a shared dynamic lib, which removes and resolves the issue.
+
+Since the `linux-release` preset and binaries are the main build used in everything from all of the Docker imaages, k8s deployment, the build workflows (build, test, publish docker, upload artifacts, the release, the docs, README, the build envirnoment setupo scripts, etc. etc.) everywhere its used needs to now be replaced wuthg the new dynamic preset build, `linux-dynamic-release`.
+
+## Tasks
+
+Analyze the project and updaate the references, then validate everything.
+
+Success looks like:
+
+- the cmake preset can configure and build successfully
+- all test pass
+- all the updtaed build and test etc. workflows succeed
+- anything else you find that needs to be updated
+
+## Acceptance Criteria
+
+- All the above tasks are completed and validated.
+
+## Plan
+
+Create a plan in a new markdown file to accomplish the above tasks.
+
+- Present options with pros and cons, and recommend a course of action with why.
+- Present to me for approval.
+
+## Branch
+
+Create n new branch and PR for this work. Branch/PR's base should be the `nam20485` branch.

--- a/docs/linux-dynamic-release-plan.md
+++ b/docs/linux-dynamic-release-plan.md
@@ -1,0 +1,137 @@
+# linux-dynamic-release Rollout Plan
+
+> Implementation plan for replacing the `linux-release` preset/binaries with the
+> `linux-dynamic-release` preset/binaries as the main Linux build.
+> Source request: [`docs/linux-dynamic-release-plan-prompt.md`](./linux-dynamic-release-plan-prompt.md)
+
+## Objective
+
+Replace every *active* reference to the `linux-release` CMake preset (builds,
+binaries, Docker images, CI workflows, artifact packaging, docs, helper
+scripts) with the `linux-dynamic-release` preset, and validate end-to-end.
+
+## Background
+
+`linux-release` links vcpkg dependencies (protobuf in particular) **statically**
+into both `libOdbDesign.so` and the `OdbDesignServer` executable. At runtime two
+independent copies of the protobuf descriptor pool are loaded, which leads to
+dereferencing uninitialized pointers and crashes (release-only `SIGABRT` on
+`GET /filemodels/<design>/matrix/matrix`).
+
+`linux-dynamic-release` sets `VCPKG_TARGET_TRIPLET=x64-linux-dynamic`, so
+protobuf/gRPC/libarchive/zlib/etc. are linked as **shared** libraries and a
+single runtime copy is used process-wide. Both presets (configure/build/test)
+already exist in `CMakePresets.json`.
+
+## Decision: what "replace" means
+
+| Item | Decision |
+|---|---|
+| `linux-release` presets in `CMakePresets.json` | **Kept** but unused. `linux-mingw-w64-release` inherits from the configure preset, so removal would require rework with no benefit. |
+| Historical docs (`plan_docs/*`, `docs/grpc/*` dev plans, `docs/workflow-optimization-analysis.md`, `docs/crash issue.txt`) | **Untouched** — they are records of past work. |
+| Disabled workflows (`.github/workflows/disabled/*`) | **Updated** for consistency if ever re-enabled. |
+| `code-coverage.yml` (uses `linux-debug`) | **Out of scope** — it never used `linux-release`, and staying on the static debug build keeps the coverage baseline comparable. |
+| k8s manifests / compose files | **No change needed** — they consume the published image, which is rebuilt from the updated Dockerfiles/workflows. |
+
+## Options considered
+
+### Option A — Ship vcpkg shared libraries alongside the binaries (chosen)
+
+Copy `vcpkg_installed/x64-linux-dynamic/lib/*.so*` (plus `ossl-modules/`) next
+to the server binary in both the Docker runtime image and the CI artifact zip.
+The existing `LD_LIBRARY_PATH=/OdbDesign/bin` env in both Dockerfiles already
+makes them discoverable.
+
+- **Pros:** simple, deterministic, no host-specific tooling; works identically
+  in the full `Dockerfile`, `Dockerfile.prebuilt`, and local scripts; OpenSSL 3
+  providers resolve because `ossl-modules/` sits next to `libcrypto.so`.
+- **Cons:** ships a few libraries that may not be strictly required; artifact
+  zips grow by roughly tens of MB (also affects public release downloads).
+
+### Option B — `ldd`-filtered copy
+
+Run `ldd` on the built binaries in the build stage and copy only the resolved
+dependencies.
+
+- **Pros:** minimal set of shipped libraries.
+- **Cons:** extra build-stage scripting, fragile against loader differences,
+  harder to audit; saves little in practice.
+
+### Option C — `vcpkg export` a runtime package
+
+Use `vcpkg export` to produce a standalone runtime bundle.
+
+- **Pros:** "official" vcpkg mechanism.
+- **Cons:** `vcpkg export` is poorly supported for dynamic Linux triplets,
+  adds a slow extra step, and duplicates what a glob copy already achieves.
+
+**Recommendation: Option A.** Simplicity and robustness win; the size cost is
+acceptable.
+
+## Changes
+
+### Build & packaging (substantive)
+
+1. **`Dockerfile`**
+   - Pre-install matches the preset triplet:
+     `vcpkg install --triplet x64-linux-dynamic` (the old static pre-install
+     would build packages the dynamic build never uses).
+   - `cmake --preset linux-dynamic-release` /
+     `cmake --build --preset linux-dynamic-release`.
+   - Runtime stage: copy the project binaries from
+     `out/build/linux-dynamic-release/...` and add
+     `COPY --from=build .../vcpkg_installed/x64-linux-dynamic/lib/*.so* ./bin/`
+     plus the `ossl-modules/` directory.
+2. **`Dockerfile.prebuilt`**
+   - `COPY ./artifacts/*.so ./bin/` → `COPY ./artifacts/*.so* ./bin/` so
+     versioned libraries (`libarchive.so.13`, `libprotobuf.so.33.x`, ...) ship.
+3. **`.github/workflows/cmake-multi-platform.yml`**
+   - Matrix preset: `linux-release` → `linux-dynamic-release`.
+   - Manual vcpkg install: Linux passes `--triplet x64-linux-dynamic`;
+     macOS keeps its default triplet (split into two conditional steps).
+   - Linux artifact step: also copy the vcpkg shared libs into the artifact
+     dir; zip glob `./*.so` → `./*.so*`.
+4. **`.github/workflows/vcpkg-cache-warm.yml`**
+   - `warm-linux` warms **both** triplets: static (still consumed by
+     `code-coverage.yml`'s `linux-debug`) and dynamic (new; must be pushed to
+     the GitHub Packages NuGet feed so future builds hit the cache).
+5. **Disabled workflows** — `disabled/test-runtime.yml`, `disabled/codeql.yml`:
+   preset matrix entry updated to `linux-dynamic-release`.
+6. **Scripts** — `scripts/compress-artifacts.sh` (paths + vcpkg libs + zip
+   glob), `scripts/compress-artifacts.ps1` (stale header comments),
+   `scripts/run-codeql-local.ps1` (Linux build command).
+
+### Docs
+
+- `AGENTS.md`, `docs/BUILD.md`, `docs/README.md`, `scripts/README.md` — Linux
+  examples switched to `linux-dynamic-release`, with a note that Linux release
+  binaries now depend on the bundled vcpkg shared libraries.
+
+## Verification
+
+1. **Local build**: `cmake --preset linux-dynamic-release` +
+   `cmake --build --preset linux-dynamic-release`.
+2. **Tests**: `ctest` against `out/build/linux-dynamic-release` with
+   `ODB_TEST_DATA_DIR` / `ODB_TEST_ENVIRONMENT_VARIABLE` set.
+3. **Runtime smoke (host)**: run `OdbDesignServer` from the dynamic build dir;
+   `curl /healthz/live`, then the previously crashing
+   `GET /filemodels/<design>/matrix/matrix` endpoint.
+4. **Prebuilt image simulation**: assemble `./artifacts` exactly like the
+   workflow does (project `.so`s + `OdbDesignServer` + vcpkg `*.so*`),
+   `docker build -f Dockerfile.prebuilt`, run the container with a test design
+   mounted, and curl healthz + the matrix endpoint.
+5. **Workflow YAML** sanity-checked after edits.
+6. **CI gate**: push the branch, open a PR against `nam20485`; the
+   `CMake Build Multi-Platform` + `Code Coverage` PR checks are the final
+   validation. (`docker-publish` only runs post-merge on the tracked branches.)
+
+## Migration notes / known impacts
+
+- **First CI run** builds the dynamic-triplet vcpkg packages from source once
+  (~one-time cost); the `vcpkg-cache-warm` job then pushes them to the feed.
+- **Artifact / release zip size** grows (vcpkg shared libs are included).
+- **`compose.local.yml` (`USE_VCPKG_CACHE=1`)** builds will cache-miss (the
+  read-only feed only holds static packages until the warm job pushes dynamic
+  ones). Workaround: build once with `USE_VCPKG_CACHE=0`, or wait for the
+  warm job.
+- Branch: `linux-dynamic-release-rollout`, PR base: `nam20485`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -156,7 +156,7 @@ export ODB_TEST_DATA_DIR=./OdbDesignTestData/TEST_DATA
 
 ```bash
 # CI test execution
-./scripts/run-tests.sh --preset linux-release --verbose
+./scripts/run-tests.sh --preset linux-dynamic-release --verbose
 
 # Coverage for CI
 ./scripts/coverage.sh --summary
@@ -206,7 +206,7 @@ These scripts are designed to work in CI environments:
 ### GitHub Actions Usage
 ```yaml
 - name: Run Tests
-  run: ./scripts/run-tests.sh --preset linux-release
+  run: ./scripts/run-tests.sh --preset linux-dynamic-release
 
 - name: Generate Coverage
   run: ./scripts/coverage.sh --html
@@ -222,7 +222,7 @@ These scripts are designed to work in CI environments:
 ```bash
 # Simulate CI environment
 export CI=true
-./scripts/run-tests.sh --preset linux-release --verbose
+./scripts/run-tests.sh --preset linux-dynamic-release --verbose
 ```
 
 ## Troubleshooting

--- a/scripts/compress-artifacts.ps1
+++ b/scripts/compress-artifacts.ps1
@@ -1,12 +1,12 @@
 
 
-# COPY --from=build /src/OdbDesign/out/build/linux-release/OdbDesignLib/*.so .
-# COPY --from=build /src/OdbDesign/out/build/linux-release/Utils/*.so .
-# COPY --from=build /src/OdbDesign/out/build/linux-release/OdbDesignServer/OdbDesignServer .
+# COPY --from=build /src/OdbDesign/out/build/linux-dynamic-release/OdbDesignLib/*.so .
+# COPY --from=build /src/OdbDesign/out/build/linux-dynamic-release/Utils/*.so .
+# COPY --from=build /src/OdbDesign/out/build/linux-dynamic-release/OdbDesignServer/OdbDesignServer .
 
 New-Item -ItemType Directory -Force -Path ".\artifacts" -V
 Copy-Item -Path ".\out\build\x64-release\*.dll" -Destination ".\artifacts" -Force -V
-Copy-Item -Path ".\out\build\x64-release\OdbDesignServer.exe" -Destination ".\artifacts" -Force -V    
-# COPY --from=build /src/OdbDesign/out/build/linux-release/OdbDesignLib/*.so .
-# COPY --from=build /src/OdbDesign/out/build/linux-release/Utils/*.so .  
+Copy-Item -Path ".\out\build\x64-release\OdbDesignServer.exe" -Destination ".\artifacts" -Force -V
+# COPY --from=build /src/OdbDesign/out/build/linux-dynamic-release/OdbDesignLib/*.so .
+# COPY --from=build /src/OdbDesign/out/build/linux-dynamic-release/Utils/*.so .
 Compress-Archive -Path ".\artifacts\*.dll",".\artifacts\*.exe"  -DestinationPath ".\artifacts\artifacts.zip" -V -Force

--- a/scripts/compress-artifacts.sh
+++ b/scripts/compress-artifacts.sh
@@ -10,7 +10,11 @@ cp ./out/build/linux-dynamic-release/Utils/*.so ./artifacts
 cp ./out/build/linux-dynamic-release/OdbDesignServer/OdbDesignServer ./artifacts
 # vcpkg shared libraries (protobuf, gRPC, ...) required at runtime by the
 # linux-dynamic-release build; Dockerfile.prebuilt copies *.so*
-cp ./out/build/linux-dynamic-release/vcpkg_installed/x64-linux-dynamic/lib/*.so* ./artifacts
+# -P preserves vcpkg's dev symlinks (libfoo.so -> libfoo.so.N -> real file) so
+# each lib ships once; zip -y below stores them as links
+cp -P ./out/build/linux-dynamic-release/vcpkg_installed/x64-linux-dynamic/lib/*.so* ./artifacts
+# OpenSSL 3 provider modules (resolved relative to libcrypto.so's dir)
+cp -r ./out/build/linux-dynamic-release/vcpkg_installed/x64-linux-dynamic/lib/ossl-modules ./artifacts/
 #cp ./out/build/linux-dynamic-release/OdbDesignServer/*.so ./artifacts
 cd ./artifacts
-zip -r -y ./artifacts.zip ./*.so* ./OdbDesignServer
+zip -r -y ./artifacts.zip ./*.so* ./ossl-modules ./OdbDesignServer

--- a/scripts/compress-artifacts.sh
+++ b/scripts/compress-artifacts.sh
@@ -1,13 +1,16 @@
 #!/bin/sh
 
-# COPY --from=build /src/OdbDesign/out/build/linux-release/OdbDesignLib/*.so .
-# COPY --from=build /src/OdbDesign/out/build/linux-release/Utils/*.so .
-# COPY --from=build /src/OdbDesign/out/build/linux-release/OdbDesignServer/OdbDesignServer .
+# COPY --from=build /src/OdbDesign/out/build/linux-dynamic-release/OdbDesignLib/*.so .
+# COPY --from=build /src/OdbDesign/out/build/linux-dynamic-release/Utils/*.so .
+# COPY --from=build /src/OdbDesign/out/build/linux-dynamic-release/OdbDesignServer/OdbDesignServer .
 
 mkdir ./artifacts
-cp ./out/build/linux-release/OdbDesignLib/*.so ./artifacts
-cp ./out/build/linux-release/Utils/*.so ./artifacts
-cp ./out/build/linux-release/OdbDesignServer/OdbDesignServer ./artifacts
-#cp ./out/build/linux-release/OdbDesignServer/*.so ./artifacts
+cp ./out/build/linux-dynamic-release/OdbDesignLib/*.so ./artifacts
+cp ./out/build/linux-dynamic-release/Utils/*.so ./artifacts
+cp ./out/build/linux-dynamic-release/OdbDesignServer/OdbDesignServer ./artifacts
+# vcpkg shared libraries (protobuf, gRPC, ...) required at runtime by the
+# linux-dynamic-release build; Dockerfile.prebuilt copies *.so*
+cp ./out/build/linux-dynamic-release/vcpkg_installed/x64-linux-dynamic/lib/*.so* ./artifacts
+#cp ./out/build/linux-dynamic-release/OdbDesignServer/*.so ./artifacts
 cd ./artifacts
-zip -r ./artifacts.zip ./*.so ./OdbDesignServer
+zip -r -y ./artifacts.zip ./*.so* ./OdbDesignServer

--- a/scripts/run-codeql-local.ps1
+++ b/scripts/run-codeql-local.ps1
@@ -52,7 +52,8 @@ if (-not (Test-Path $DatabasePath) -or $Clean) {
         $createCmd = "codeql database create `"$DatabasePath`" --language=cpp --source-root=. --overwrite"
     } else {
         # Create database with build
-        $buildCmd = "cmake --preset linux-release && cmake --build --preset linux-release"
+        # linux-dynamic-release: shared protobuf/gRPC runtime (see docs/linux-dynamic-release-plan.md)
+        $buildCmd = "cmake --preset linux-dynamic-release && cmake --build --preset linux-dynamic-release"
         $createCmd = "codeql database create `"$DatabasePath`" --language=cpp --command=`"$buildCmd`" --source-root=. --overwrite"
     }
     

--- a/scripts/setup-linux.sh
+++ b/scripts/setup-linux.sh
@@ -292,16 +292,28 @@ setup_environment() {
     print_success "Environment configured"
 }
 
+# Map BUILD_TYPE to the main Linux CMake preset.
+# Release uses the dynamic triplet (shared protobuf/gRPC) — the static
+# linux-release preset loads two protobuf copies at runtime and crashes;
+# see docs/linux-dynamic-release-plan.md.
+get_preset() {
+    if [[ "$BUILD_TYPE" == "Release" ]]; then
+        echo "linux-dynamic-release"
+    else
+        echo "linux-$(echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]')"
+    fi
+}
+
 # Build the project
 build_project() {
     if [[ "$SKIP_BUILD" == "true" ]]; then
         print_status "Skipping build as requested"
         return
     fi
-    
+
     print_status "Building OdbDesign ($BUILD_TYPE)..."
-    
-    local preset="linux-$(echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]')"
+
+    local preset="$(get_preset)"
     
     # Configure
     print_status "Configuring with preset: $preset"
@@ -328,8 +340,8 @@ build_project() {
 run_tests() {
     if [[ "$BUILD_TESTS" == "true" ]]; then
         print_status "Running tests..."
-        
-        local preset="linux-$(echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]')"
+
+        local preset="$(get_preset)"
         
         if ctest --preset "$preset" --output-on-failure; then
             print_success "All tests passed"
@@ -416,9 +428,9 @@ main() {
     echo "  1. Restart your shell or run: source ~/.bashrc"
     echo "  2. Navigate to the project directory"
     if [[ "$SKIP_BUILD" == "false" ]]; then
-        echo "  3. Run the server: ./out/build/linux-$(echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]')/OdbDesignServer"
+        echo "  3. Run the server: ./out/build/$(get_preset)/OdbDesignServer"
     else
-        echo "  3. Build the project: cmake --preset linux-$(echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]') && cmake --build --preset linux-$(echo $BUILD_TYPE | tr '[:upper:]' '[:lower:]')"
+        echo "  3. Build the project: cmake --preset $(get_preset) && cmake --build --preset $(get_preset)"
     fi
     echo "  4. Access the API at: http://localhost:8888"
     echo


### PR DESCRIPTION
## Summary

Replaces `linux-release` as the main Linux preset with `linux-dynamic-release` (`VCPKG_TARGET_TRIPLET=x64-linux-dynamic`) across CI, packaging, scripts, and docs, per [`docs/linux-dynamic-release-plan.md`](docs/linux-dynamic-release-plan.md).

**Why:** `linux-release` links protobuf statically into both `libOdbDesign.so` and `OdbDesignServer` → two descriptor pools at runtime → release-only `SIGABRT` on `GET /filemodels/<design>/matrix/matrix`. The dynamic triplet links a single shared protobuf/gRPC runtime and eliminates the crash (full analysis in `docs/crash issue.txt`).

## Changes

- **`cmake-multi-platform.yml`**: matrix preset → `linux-dynamic-release`; triplet-matched `vcpkg install --triplet x64-linux-dynamic` on Linux; Linux artifacts now bundle the vcpkg shared libs (`*.so*`) required at runtime
- **`Dockerfile.prebuilt`**: `COPY ./artifacts/*.so*` so versioned sonames (`libprotobuf.so.33`, `libarchive.so.13`, …) ship in the image
- **`vcpkg-cache-warm.yml`**: `warm-linux` warms both static (still used by `code-coverage.yml`'s `linux-debug`) and dynamic triplets — first CI dynamic build runs from source once, then is NuGet-cached
- **Disabled workflows** (`test-runtime`, `codeql`), **`scripts/compress-artifacts.{sh,ps1}`**, **`scripts/run-codeql-local.ps1`**: preset references updated
- **Docs**: `AGENTS.md`, `docs/BUILD.md`, `docs/README.md`, `scripts/README.md` — Linux commands now use `linux-dynamic-release`, with notes about the bundled vcpkg shared libs
- **Plan doc** added: `docs/linux-dynamic-release-plan.md` (+ the original request prompt)

### Decisions (from plan approval)

- `linux-release` presets **kept** in `CMakePresets.json` but unused (`linux-mingw-w64-release` inherits from them; removal = rework for no benefit)
- Historical `plan_docs/*`, `docs/grpc/*`, `docs/crash issue.txt`, `docs/workflow-optimization-analysis.md` left untouched as records
- `code-coverage.yml` stays on `linux-debug` (never used `linux-release`; keeps coverage baseline comparable)
- k8s manifests / compose: no change (they consume the published image, which is rebuilt by the updated workflows)

> Note: the `Dockerfile` (full-build) changes for this rollout were already merged to `nam20485` in PR #561; this PR contains the remaining CI/packaging/scripts/docs changes.

## Validation

- [x] `cmake --preset linux-dynamic-release` configure + build: clean (104/104 targets)
- [x] `ctest`: **139/139 pass** (`linux-dynamic-release`, `ODB_TEST_DATA_DIR` + `ODB_TEST_ENVIRONMENT_VARIABLE` set)
- [x] Host runtime smoke: server up, `GET /healthz/live` → 200, **`GET /filemodels/sample_design/matrix/matrix` → 200 with matrix JSON** (the exact crash repro from `docs/crash issue.txt`) — process stayed alive
- [x] `Dockerfile.prebuilt` simulation: assembled the artifact set exactly as the CI workflow does (project `.so`s + server + vcpkg `*.so*`, ~85MB / 112 files), built the image, ran the container (healthy), authenticated `matrix/matrix` → **200**, gRPC server listening on 50051
- [x] Workflow YAML syntax validated after rebase onto latest `nam20485`

## Known impacts

- First CI Linux build compiles the dynamic-triplet packages from source once (no NuGet cache entries yet); `vcpkg-cache-warm` then pushes them
- Linux artifact/release zip size grows (~85MB of vcpkg shared libs added)
- `compose.local.yml` `USE_VCPKG_CACHE=1` builds cache-miss until the warm job populates dynamic packages