### PR TITLE
fix(ci): sanitize workflow branch values in Docker workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -122,14 +122,29 @@ jobs:
 
       # Set branch name for workflow_run events (uses triggering workflow's branch)
       - name: Set Branch Name
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REF_NAME: ${{ github.ref_name }}
+          CURRENT_SHA: ${{ github.sha }}
         run: |
-          if [ "${{ github.event_name }}" == "workflow_run" ]; then
-            echo "BRANCH_NAME=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_ENV
-            echo "COMMIT_SHA=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_ENV
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            branch_name="$WORKFLOW_RUN_HEAD_BRANCH"
+            commit_sha="$WORKFLOW_RUN_HEAD_SHA"
           else
-            echo "BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_ENV
-            echo "COMMIT_SHA=${{ github.sha }}" >> $GITHUB_ENV
+            branch_name="$REF_NAME"
+            commit_sha="$CURRENT_SHA"
           fi
+
+          if ! printf '%s' "$branch_name" | grep -Eq '^[A-Za-z0-9._/-]+$'; then
+            echo "Invalid branch name: $branch_name" >&2
+            exit 1
+          fi
+
+          safe_branch_name="${branch_name//\//-}"
+          printf 'BRANCH_NAME=%s\n' "$safe_branch_name" >> "$GITHUB_ENV"
+          printf 'COMMIT_SHA=%s\n' "$commit_sha" >> "$GITHUB_ENV"
 
       - name: Echo Environment Variables
         run: |

--- a/.github/workflows/docker-scout-scan.yml
+++ b/.github/workflows/docker-scout-scan.yml
@@ -58,18 +58,28 @@ jobs:
       # Determine which branch/tag to scan
       - name: Set Image Tag
         id: set-tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          INPUT_BRANCH: ${{ inputs.branch }}
         run: |
-          if [ "${{ github.event_name }}" == "workflow_run" ]; then
-            echo "SCAN_TAG=${{ github.event.workflow_run.head_branch }}-latest" >> $GITHUB_ENV
-            echo "BRANCH_NAME=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_ENV
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "SCAN_TAG=${{ inputs.branch }}-latest" >> $GITHUB_ENV
-            echo "BRANCH_NAME=${{ inputs.branch }}" >> $GITHUB_ENV
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            branch_name="$WORKFLOW_RUN_HEAD_BRANCH"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            branch_name="$INPUT_BRANCH"
           else
             # Scheduled run - scan development by default
-            echo "SCAN_TAG=development-latest" >> $GITHUB_ENV
-            echo "BRANCH_NAME=development" >> $GITHUB_ENV
+            branch_name="development"
           fi
+
+          if ! printf '%s' "$branch_name" | grep -Eq '^[A-Za-z0-9._/-]+$'; then
+            echo "Invalid branch name: $branch_name" >&2
+            exit 1
+          fi
+
+          safe_branch_name="${branch_name//\//-}"
+          printf 'BRANCH_NAME=%s\n' "$safe_branch_name" >> "$GITHUB_ENV"
+          printf 'SCAN_TAG=%s-latest\n' "$safe_branch_name" >> "$GITHUB_ENV"
 
       # Login against Docker Hub to allow running Docker Scout
       - name: Log into Docker Hub registry


### PR DESCRIPTION
## What

Ports `e03672b` from `main` — the only commit on `main` that never made it back to `development`.

Both `docker-publish.yml` and `docker-scout-scan.yml` interpolated untrusted event context directly into `run:` shell blocks:

```yaml
run: |
  if [ "${{ github.event_name }}" == "workflow_run" ]; then
    echo "BRANCH_NAME=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_ENV
```

`github.event.workflow_run.head_branch` and `inputs.branch` are attacker-influenceable, so this is the standard GitHub Actions script-injection pattern. The fix routes the values through `env:` and validates before use:

```yaml
if ! printf '%s' "$branch_name" | grep -Eq '^[A-Za-z0-9._/-]+$'; then
  echo "Invalid branch name: $branch_name" >&2
  exit 1
fi
safe_branch_name="${branch_name//\//-}"
```

## Why this is needed

`main` was rebuilt by rebasing development's commits onto it (270 commits replayed 2026-04-15..17), so its SHAs no longer match development's. `git cherry` shows 259 of main's 270 unique commits are patch-identical to commits already in development — this was the one that wasn't. It has been sitting un-backported since 2026-04-17.

## Verification

- Cherry-picked clean, no conflicts.
- Both files parse as valid YAML.
- Development's newer changes in the same file are preserved: `nam20485` in the `workflow_run.branches` list, and the `ref: ...head_sha` checkout that fixes the stale-`Dockerfile.prebuilt` CrashLoopBackOff.
- Audited every remaining `${{ }}` in both files: all `github.event.*` / `inputs.*` references now sit in `env:` mappings or action `with:` inputs, none inside a `run:` block. `COMPARE_TAG` is a hardcoded workflow-level env (`latest`), not event-derived.

## Note on merge strategy

Please **merge-commit** this, don't squash or rebase. `main` is about to be re-baselined onto `development` to clear the phantom divergence, and squash-merging is one of the things that generated it.