### PR TITLE
fix(pages): stop Jekyll choking on quoted GitHub Actions expressions

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -131,11 +131,12 @@ Tests run automatically on every push and pull request via GitHub Actions. The C
 
 ### CI Test Execution
 
+{% raw %}
 ```yaml
 - name: CMake Test
-  run: ctest --test-dir ./out/build/${{matrix.preset}}/OdbDesignTests 
-       --output-log testlog.txt 
-       --output-junit testlog.xml 
+  run: ctest --test-dir ./out/build/${{matrix.preset}}/OdbDesignTests
+       --output-log testlog.txt
+       --output-junit testlog.xml
        --output-on-failure
 
 - name: Report Test Results
@@ -145,6 +146,7 @@ Tests run automatically on every push and pull request via GitHub Actions. The C
     path: testlog.xml
     reporter: java-junit
 ```
+{% endraw %}
 
 ## Test Development
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,3 +8,18 @@ show_downloads: false
 
 url: https://source.odbdesignserver.com
 #baseurl: /jekyll-blog-demo
+
+# Liquid runs before Markdown, so it also expands expressions inside fenced code
+# blocks. These docs quote GitHub Actions syntax. A quote nested in {{ }} — e.g.
+# format('{0}/{1}', ...) or hashFiles('vcpkg.json') — stops Liquid's variable
+# tokenizer from finding the closing }}, which aborts the entire site build; a
+# quote-free expression instead renders as empty and silently holes the published
+# text. Add any new doc that quotes Actions expressions here, or {% raw %}-fence
+# it if the page should stay published.
+exclude:
+- plan/argocd-deployment-plan.md
+- plan/argocd-gitops-handoff.md
+- vcpkg-binary-cache/fix-cmake-workflow-caching-plan.md
+- vcpkg-binary-cache/github-packages-MS-tutorial.md
+- vcpkg-binary-cache/vcpkg-github-packages-plan.md
+- workflow-optimization-analysis.md


### PR DESCRIPTION
## What

`release` was re-baselined onto `development` earlier today, which pulled in docs that had never been on `release`. That broke the GitHub Pages deploy:

```
Liquid Exception: Liquid syntax error (line 495): Variable '{{ github.event_name ==
'pull_request' && format('{0}' was not properly terminated with regexp: /\}\}/
in plan/argocd-deployment-plan.md
```

Liquid expands `{{ }}` **before** Markdown renders, so it also processes expressions inside fenced code blocks. When a quote is nested inside the braces, Liquid's variable tokenizer can never find the closing `}}` and the entire site build aborts.

`jekyll-gh-pages.yml` triggers only on `push: branches: ["release"]`, so `development` never exercised this path.

## Classification

Scanned all 82 docs under `docs/` for `{{ }}` / `{% %}`:

**Hard breakers** (quote nested in braces -> aborts the build):
- `plan/argocd-deployment-plan.md` — `format('{0}/{1}', ...)`
- `vcpkg-binary-cache/fix-cmake-workflow-caching-plan.md` — `hashFiles('vcpkg.json', 'vcpkg-configuration.json')`
- `workflow-optimization-analysis.md` — `hashFiles('vcpkg.json')`

**Soft manglers** (quote-free -> build passes, but expression renders as empty and silently holes the published text):
- `TESTING.md`, `plan/argocd-gitops-handoff.md`, `vcpkg-binary-cache/github-packages-MS-tutorial.md`, `vcpkg-binary-cache/vcpkg-github-packages-plan.md`

## Fix

- `docs/_config.yml`: `exclude` the six internal plan / analysis / reference docs. Comment records the invariant so the next doc that quotes an Actions expression gets added rather than rediscovered via a red build.
- `docs/TESTING.md`: `{% raw %}`-fence the CI snippet instead of excluding it, so the user-facing testing guide stays published and renders `${{matrix.preset}}` literally.

## Verification

Re-ran the detector against the post-fix tree, stripping `{% raw %}` regions the way Liquid would and skipping excluded paths:

- `_config.yml` parses; all 6 exclude entries resolve to real files (a typo would silently exclude nothing)
- hard breakers remaining in built docs: **0**
- soft manglers remaining in built docs: **0**

Docs-only change, no C++ or workflow impact.