### PR TITLE
Promote nam20485 -> development: fix(pages) Jekyll Liquid exclusions

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -131,11 +131,12 @@ Tests run automatically on every push and pull request via GitHub Actions. The C
 
 ### CI Test Execution
 
+{% raw %}
 ```yaml
 - name: CMake Test
-  run: ctest --test-dir ./out/build/${{matrix.preset}}/OdbDesignTests 
-       --output-log testlog.txt 
-       --output-junit testlog.xml 
+  run: ctest --test-dir ./out/build/${{matrix.preset}}/OdbDesignTests
+       --output-log testlog.txt
+       --output-junit testlog.xml
        --output-on-failure
 
 - name: Report Test Results
@@ -145,6 +146,7 @@ Tests run automatically on every push and pull request via GitHub Actions. The C
     path: testlog.xml
     reporter: java-junit
 ```
+{% endraw %}
 
 ## Test Development
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,3 +8,18 @@ show_downloads: false
 
 url: https://source.odbdesignserver.com
 #baseurl: /jekyll-blog-demo
+
+# Liquid runs before Markdown, so it also expands expressions inside fenced code
+# blocks. These docs quote GitHub Actions syntax. A quote nested in {{ }} — e.g.
+# format('{0}/{1}', ...) or hashFiles('vcpkg.json') — stops Liquid's variable
+# tokenizer from finding the closing }}, which aborts the entire site build; a
+# quote-free expression instead renders as empty and silently holes the published
+# text. Add any new doc that quotes Actions expressions here, or {% raw %}-fence
+# it if the page should stay published.
+exclude:
+- plan/argocd-deployment-plan.md
+- plan/argocd-gitops-handoff.md
+- vcpkg-binary-cache/fix-cmake-workflow-caching-plan.md
+- vcpkg-binary-cache/github-packages-MS-tutorial.md
+- vcpkg-binary-cache/vcpkg-github-packages-plan.md
+- workflow-optimization-analysis.md


### PR DESCRIPTION
Promotion hop of #572 (docs-only: `docs/_config.yml` exclude list + `{% raw %}` fence in `docs/TESTING.md`). Restores the GitHub Pages deploy on `release`, which broke when `release` was re-baselined onto `development` and picked up docs quoting GitHub Actions expressions. Merged with admin bypass: no C++, workflow, or build-system impact, so the required CMake/SBOM/Codacy checks cannot detect a regression. Merge commit per repo policy.