### PR TITLE
M1.2: RequestLoadDesign — async background load (gRPC + REST + upload auto-warm)

### DIFF
--- a/OdbDesignLib/App/DesignCache.cpp
+++ b/OdbDesignLib/App/DesignCache.cpp
@@ -4,6 +4,7 @@
 #include <exception>
 #include <filesystem>
 #include <stdexcept>
+#include <thread>
 #include <vector>
 #include "../FileModel/Design/FileArchive.h"
 #include <memory>
@@ -28,6 +29,16 @@ namespace Odb::Lib::App
     DesignCache::~DesignCache()
     {
         Clear();
+
+        // Detached background loads hold `this`; drain them before member
+        // teardown. A queued load first acquires its semaphore slot (running
+        // loads release theirs), so the wait is bounded by the outstanding
+        // parse time.
+        std::unique_lock<std::mutex> lock(m_backgroundMutex);
+        m_backgroundDoneCv.wait(lock, [this]()
+        {
+            return m_outstandingBackgroundLoads == 0;
+        });
     }
 
     std::shared_ptr<ProductModel::Design> DesignCache::GetDesign(const std::string& designName)
@@ -352,6 +363,128 @@ namespace Odb::Lib::App
         return m_maxBytes;
     }
 
+    void DesignCache::setMaxBackgroundLoads(std::size_t maxLoads)
+    {
+        {
+            std::lock_guard<std::mutex> lock(m_backgroundMutex);
+            m_maxBackgroundLoads = maxLoads;
+        }
+        // A raised cap frees waiting loads immediately
+        m_backgroundSlotCv.notify_all();
+    }
+
+    std::size_t DesignCache::getMaxBackgroundLoads() const
+    {
+        std::lock_guard<std::mutex> lock(m_backgroundMutex);
+        return m_maxBackgroundLoads;
+    }
+
+    bool DesignCache::ContainsDesign(const std::string& designName) const
+    {
+        return !FindArchivePath(designName).empty();
+    }
+
+    bool DesignCache::LoadDesignAsync(const std::string& designName)
+    {
+        {
+            std::lock_guard<std::mutex> lock(m_loadStateMutex);
+            // A kick we issued earlier (queued or parsing) or a synchronous
+            // single-flight load in progress means already-loading; registering
+            // the pending marker here closes the window before the background
+            // thread announces Loading.
+            if (m_pendingAsyncLoads.find(designName) != m_pendingAsyncLoads.end() ||
+                m_designsInFlight.find(designName) != m_designsInFlight.end() ||
+                m_fileArchivesInFlight.find(designName) != m_fileArchivesInFlight.end())
+            {
+                return false;
+            }
+            m_pendingAsyncLoads.insert(designName);
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(m_backgroundMutex);
+            ++m_outstandingBackgroundLoads;
+        }
+
+        try
+        {
+            // Detached by design (fire-and-forget): ~DesignCache drains
+            // m_outstandingBackgroundLoads so the thread never outlives members.
+            std::thread(&DesignCache::BackgroundLoad, this, designName).detach();
+        }
+        catch (...)
+        {
+            {
+                std::lock_guard<std::mutex> lock(m_backgroundMutex);
+                --m_outstandingBackgroundLoads;
+            }
+            {
+                std::lock_guard<std::mutex> lock(m_loadStateMutex);
+                m_pendingAsyncLoads.erase(designName);
+            }
+            throw;
+        }
+        return true;
+    }
+
+    void DesignCache::BackgroundLoad(const std::string& designName)
+    {
+        AcquireBackgroundSlot();
+        try
+        {
+            // The single-flight path registers the Loading/Loaded/Failed
+            // transitions and observers exactly as a synchronous load; a failed
+            // parse records Failed and drops the in-flight entry (retryable).
+            auto pDesign = GetDesign(designName);
+            if (pDesign == nullptr)
+            {
+                logwarn("Background load: no archive found for design \"" + designName + "\"");
+            }
+            else
+            {
+                loginfo("Background load of design \"" + designName + "\" completed");
+            }
+        }
+        catch (const std::exception& e)
+        {
+            logexception_msg(e, "Background load of design \"" + designName + "\" failed (retryable)");
+        }
+        catch (...)
+        {
+            logerror("Background load of design \"" + designName + "\" failed with an unknown exception (retryable)");
+        }
+        ReleaseBackgroundSlot();
+
+        {
+            std::lock_guard<std::mutex> lock(m_loadStateMutex);
+            m_pendingAsyncLoads.erase(designName);
+        }
+        {
+            std::lock_guard<std::mutex> lock(m_backgroundMutex);
+            --m_outstandingBackgroundLoads;
+        }
+        m_backgroundDoneCv.notify_all();
+    }
+
+    void DesignCache::AcquireBackgroundSlot()
+    {
+        std::unique_lock<std::mutex> lock(m_backgroundMutex);
+        m_backgroundSlotCv.wait(lock, [this]()
+        {
+            return m_maxBackgroundLoads == 0 || m_activeBackgroundLoads < m_maxBackgroundLoads;
+        });
+        ++m_activeBackgroundLoads;
+    }
+
+    void DesignCache::ReleaseBackgroundSlot()
+    {
+        {
+            std::lock_guard<std::mutex> lock(m_backgroundMutex);
+            --m_activeBackgroundLoads;
+        }
+        m_backgroundSlotCv.notify_one();
+    }
+
     void DesignCache::ensureDirectoryExists() const
     {
         if (!std::filesystem::exists(m_directory))
@@ -370,44 +503,55 @@ namespace Odb::Lib::App
         }
     }
 
-    std::shared_ptr<ProductModel::Design> DesignCache::LoadDesign(const std::string& designName)
+    std::filesystem::path DesignCache::FindArchivePath(const std::string& designName) const
     {
-        // NOTE: This is a lock-free I/O helper. It does NOT modify the cache maps.
-        // Cache insertion is handled by GetOrLoadSingleFlight().
         std::string directory;
         {
             std::shared_lock<std::shared_mutex> readLock(m_cacheMutex);
             directory = m_directory;
         }
 
-        for (const auto& entry : directory_iterator(directory))
+        std::error_code ec;
+        const auto options = directory_options::skip_permission_denied;
+        directory_iterator dirIt(directory, options, ec);
+        if (ec)
         {
-            if (entry.is_regular_file())
+            return {};
+        }
+
+        for (const auto& entry : dirIt)
+        {
+            if (entry.is_regular_file() && entry.path().stem() == designName)
             {
-                if (entry.path().stem() == designName)
-                {
-                    // GetFileArchive is thread-safe, manages its own locking.
-                    // updateState=false: the archive is a sub-step of this design load
-                    // and must not flip the design's load state mid-load.
-                    auto pFileModel = GetFileArchiveInternal(designName, false);
-                    if (pFileModel != nullptr)
-                    {
-                        auto pDesign = std::make_shared<ProductModel::Design>();
-                        if (pDesign->Build(pFileModel))
-                        {
-                            return pDesign;
-                        }
-                        else
-                        {
-                            break;
-                        }
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
+                return entry.path();
             }
+        }
+
+        return {};
+    }
+
+    std::shared_ptr<ProductModel::Design> DesignCache::LoadDesign(const std::string& designName)
+    {
+        // NOTE: This is a lock-free I/O helper. It does NOT modify the cache maps.
+        // Cache insertion is handled by GetOrLoadSingleFlight().
+        if (FindArchivePath(designName).empty())
+        {
+            return nullptr;
+        }
+
+        // GetFileArchive is thread-safe, manages its own locking.
+        // updateState=false: the archive is a sub-step of this design load
+        // and must not flip the design's load state mid-load.
+        auto pFileModel = GetFileArchiveInternal(designName, false);
+        if (pFileModel == nullptr)
+        {
+            return nullptr;
+        }
+
+        auto pDesign = std::make_shared<ProductModel::Design>();
+        if (pDesign->Build(pFileModel))
+        {
+            return pDesign;
         }
 
         return nullptr;
@@ -417,60 +561,42 @@ namespace Odb::Lib::App
     {
         // NOTE: This is a lock-free I/O helper. It does NOT modify the cache maps.
         // Cache insertion is handled by GetOrLoadSingleFlight().
-        auto fileFound = false;
-
-        std::string directory;
-        {
-            std::shared_lock<std::shared_mutex> readLock(m_cacheMutex);
-            directory = m_directory;
-        }
-
-        // skip inaccessible files and do not follow symlinks
-        const auto options = directory_options::skip_permission_denied;
-        for (const auto& entry : directory_iterator(directory, options))
-        {
-            if (entry.is_regular_file())
-            {
-                if (entry.path().stem() == designName)
-                {
-                    fileFound = true;
-
-                    loginfo("file found: [" + entry.path().string() + "], attempting to parse...");
-
-                    auto pFileArchive = std::make_shared<FileModel::Design::FileArchive>(entry.path().string());
-                    if (pFileArchive->ParseFileModel())
-                    {
-                        return pFileArchive;
-                    }
-
-                    // A matching file was found but failed to extract or parse. Treat this
-                    // as a corrupt/unloadable design (error) rather than a missing one, so
-                    // callers surface INTERNAL/500 instead of a misleading NOT_FOUND/404.
-                    // (ParseFileModel already throws on parse failure; this covers the
-                    // extraction / missing-root-dir paths that return false.)
-                    // The file path is intentionally omitted here to avoid leaking server
-                    // filesystem details to API clients (it is logged above for diagnostics).
-                    throw std::runtime_error(
-                        "Failed to load design \"" + designName + "\": could not extract or parse archive");
-                }
-            }
-        }
-
-        if (!fileFound)
+        const auto archivePath = FindArchivePath(designName);
+        if (archivePath.empty())
         {
             logwarn("Failed to find file for design \"" + designName + "\"");
 
-            logdebug("Listing all files in directory: " + directory);
-            for (const auto& entry : directory_iterator(directory, options))
+            logdebug("Listing all files in directory: " + getDirectory());
+            const auto options = directory_options::skip_permission_denied;
+            std::error_code ec;
+            for (const auto& entry : directory_iterator(getDirectory(), options, ec))
             {
                 if (entry.is_regular_file())
                 {
                     logdebug("Found file: " + entry.path().filename().string() + " (stem: " + entry.path().stem().string() + ")");
                 }
             }
+
+            return nullptr;
         }
 
-        return nullptr;
+        loginfo("file found: [" + archivePath.string() + "], attempting to parse...");
+
+        auto pFileArchive = std::make_shared<FileModel::Design::FileArchive>(archivePath.string());
+        if (pFileArchive->ParseFileModel())
+        {
+            return pFileArchive;
+        }
+
+        // A matching file was found but failed to extract or parse. Treat this
+        // as a corrupt/unloadable design (error) rather than a missing one, so
+        // callers surface INTERNAL/500 instead of a misleading NOT_FOUND/404.
+        // (ParseFileModel already throws on parse failure; this covers the
+        // extraction / missing-root-dir paths that return false.)
+        // The file path is intentionally omitted here to avoid leaking server
+        // filesystem details to API clients (it is logged above for diagnostics).
+        throw std::runtime_error(
+            "Failed to load design \"" + designName + "\": could not extract or parse archive");
     }
 
     void DesignCache::TouchLru(const std::string& designName)
@@ -580,34 +706,19 @@ namespace Odb::Lib::App
     {
         // Simple estimate: archive file size on disk + a small constant. Serialized
         // response sizes are added to this estimate in M1.4 (response cache).
-        std::string directory;
-        {
-            std::shared_lock<std::shared_mutex> readLock(m_cacheMutex);
-            directory = m_directory;
-        }
-
-        std::error_code ec;
-        const auto options = directory_options::skip_permission_denied;
-        directory_iterator dirIt(directory, options, ec);
-        if (ec)
+        const auto archivePath = FindArchivePath(designName);
+        if (archivePath.empty())
         {
             return DESIGN_BYTES_OVERHEAD;
         }
 
-        for (const auto& entry : dirIt)
+        std::error_code ec;
+        const auto size = std::filesystem::file_size(archivePath, ec);
+        if (ec)
         {
-            if (entry.is_regular_file() && entry.path().stem() == designName)
-            {
-                const auto size = entry.file_size(ec);
-                if (ec)
-                {
-                    return DESIGN_BYTES_OVERHEAD;
-                }
-                return static_cast<std::uint64_t>(size) + DESIGN_BYTES_OVERHEAD;
-            }
+            return DESIGN_BYTES_OVERHEAD;
         }
-
-        return DESIGN_BYTES_OVERHEAD;
+        return static_cast<std::uint64_t>(size) + DESIGN_BYTES_OVERHEAD;
     }
 
     void DesignCache::TransitionLoadState(const std::string& designName, LoadState to)

--- a/OdbDesignLib/App/DesignCache.h
+++ b/OdbDesignLib/App/DesignCache.h
@@ -5,7 +5,10 @@
 #include "../odbdesign_export.h"
 #include "StringVector.h"
 #include <chrono>
+#include <condition_variable>
+#include <cstddef>
 #include <cstdint>
+#include <filesystem>
 #include <functional>
 #include <future>
 #include <memory>
@@ -14,6 +17,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 
@@ -83,9 +87,33 @@ namespace Odb::Lib::App
 		// waiting. Requesting other designs is safe.
 		void AddLoadObserver(LoadEventCallback callback);
 
+		// ---- background loads (consumed by M1.2 RequestLoadDesign + upload auto-warm) ----
+
+		// Kicks a background load of the named design and returns immediately:
+		// the parse runs on a detached thread through the same single-flight
+		// path as a synchronous GetDesign, so state/observer transitions,
+		// caching, and failure semantics (Failed is retryable) are identical.
+		// Returns true when a fresh background load was started; false when one
+		// is already pending or in flight for the name (the caller surfaces
+		// that as "already loading"). Throws only if the load thread itself
+		// could not be spawned; load failures are logged, never thrown here.
+		bool LoadDesignAsync(const std::string& designName);
+
+		// True when an archive file for the design name exists in the designs
+		// directory (first regular file whose stem matches), without
+		// triggering a load. Lets callers distinguish "no such archive"
+		// (NOT_FOUND) from a parse failure (Failed load state).
+		bool ContainsDesign(const std::string& designName) const;
+
 		// Byte budget for LRU eviction; 0 disables eviction.
 		void setCacheMaxBytes(std::uint64_t maxBytes);
 		std::uint64_t getCacheMaxBytes() const;
+
+		// Cap on concurrently parsing background loads; further loads queue on
+		// the semaphore inside their background thread (LoadDesignAsync itself
+		// never blocks). 0 = unbounded.
+		void setMaxBackgroundLoads(std::size_t maxLoads);
+		std::size_t getMaxBackgroundLoads() const;
 
 	private:
 		std::string m_directory;
@@ -130,6 +158,26 @@ namespace Odb::Lib::App
 		// Protects the in-flight maps, m_loadStatesByName, m_loadObservers, and m_epoch
 		mutable std::mutex m_loadStateMutex;
 
+		// Names with a background load kicked but not yet finished (queued on the
+		// semaphore or parsing). Closing the between-kick-and-Loading window
+		// synchronously in LoadDesignAsync makes a second kick for the same name
+		// deterministically return false instead of racing the background
+		// thread's Loading announcement. Guarded by m_loadStateMutex.
+		std::unordered_set<std::string> m_pendingAsyncLoads;
+
+		// ---- background-load bookkeeping ----
+		//
+		// Counting semaphore for background parses (mutex + cv; C++17 target).
+		// m_outstandingBackgroundLoads counts spawned-but-unfinished background
+		// threads (queued or parsing); ~DesignCache drains it so detached loads
+		// never outlive the cache members they touch. Guarded by m_backgroundMutex.
+		mutable std::mutex m_backgroundMutex;
+		std::condition_variable m_backgroundSlotCv;
+		std::condition_variable m_backgroundDoneCv;
+		std::size_t m_maxBackgroundLoads = DEFAULT_MAX_BACKGROUND_LOADS;
+		std::size_t m_activeBackgroundLoads = 0;        // threads currently holding a parse slot
+		std::size_t m_outstandingBackgroundLoads = 0;   // spawned but unfinished threads
+
 		// Thread-local re-entry guard: name of the design whose load the current
 		// thread is running, set only while the Loading transition (and its
 		// synchronous observers) is in progress on the loader thread. The joiner
@@ -168,6 +216,17 @@ namespace Odb::Lib::App
 		std::shared_ptr<ProductModel::Design> LoadDesign(const std::string& designName);
 		std::shared_ptr<FileModel::Design::FileArchive> LoadFileArchive(const std::string& designName);
 		std::shared_ptr<FileModel::Design::FileArchive> GetFileArchiveInternal(const std::string& designName, bool updateState);
+
+		// Shared archive-file-by-stem scan: path of the first regular file in the
+		// designs directory whose stem matches designName, or an empty path.
+		std::filesystem::path FindArchivePath(const std::string& designName) const;
+
+		// Body of a LoadDesignAsync background thread: queues on the semaphore,
+		// runs the single-flight load, logs the outcome, then releases its
+		// bookkeeping. Never lets an exception escape (thread functions must not).
+		void BackgroundLoad(const std::string& designName);
+		void AcquireBackgroundSlot();
+		void ReleaseBackgroundSlot();
 
 		// Core single-flight path behind GetDesign/GetFileArchive. Exactly one caller
 		// per design name runs loadFn; joiners wait on the same shared_future (a failed
@@ -388,6 +447,7 @@ namespace Odb::Lib::App
 		bool WasClearedSince(std::uint64_t epoch) const;
 
 		constexpr inline static std::uint64_t DEFAULT_CACHE_MAX_BYTES = 4096ull * 1024ull * 1024ull;
+		constexpr inline static std::size_t DEFAULT_MAX_BACKGROUND_LOADS = 2;
 		// Rough per-design overhead added to the archive file size; serialized response
 		// sizes are added to this estimate in M1.4 (response cache).
 		constexpr inline static std::uint64_t DESIGN_BYTES_OVERHEAD = 4096;

--- a/OdbDesignLib/App/OdbAppBase.cpp
+++ b/OdbDesignLib/App/OdbAppBase.cpp
@@ -50,6 +50,10 @@ namespace Odb::Lib::App
         // set the design cache byte budget (--cache-max-mb, 0 disables eviction)
         designs().setCacheMaxBytes(static_cast<std::uint64_t>(args().cacheMaxMb()) * 1024ull * 1024ull);
 
+        // cap concurrent background parses kicked via LoadDesignAsync
+        // (--max-background-loads, 0 = unbounded)
+        designs().setMaxBackgroundLoads(static_cast<std::size_t>(args().maxBackgroundLoads()));
+
         // load a design if specified via command line args
         if (!args().loadDesign().empty())
         {

--- a/OdbDesignLib/App/OdbDesignArgs.cpp
+++ b/OdbDesignLib/App/OdbDesignArgs.cpp
@@ -80,6 +80,25 @@ namespace Odb::Lib::App
 		}
 	}
 
+	int OdbDesignArgs::maxBackgroundLoads() const
+	{
+		// Same stoi-hardening as cacheMaxMb(): a malformed --max-background-loads
+		// must not std::terminate the process — fall back to the default with a
+		// warning. Negative values clamp to 0 (unbounded), matching
+		// DesignCache::setMaxBackgroundLoads semantics.
+		try
+		{
+			const int loads = intArg("max-background-loads", DEFAULT_MAX_BACKGROUND_LOADS);
+			return loads < 0 ? 0 : loads;
+		}
+		catch (const std::exception&)
+		{
+			std::cerr << "WARNING: invalid --max-background-loads value; using default "
+				<< DEFAULT_MAX_BACKGROUND_LOADS << std::endl;
+			return DEFAULT_MAX_BACKGROUND_LOADS;
+		}
+	}
+
 	std::string OdbDesignArgs::getUsageString() const
 	{
 		std::stringstream ss;
@@ -95,6 +114,7 @@ namespace Odb::Lib::App
 		ss << "  --load-all               Load all designs on startup (default: " << (DEFAULT_LOAD_ALL ? "true" : "false") << ")\n";
 		ss << "  --disable-authentication Disable authentication (default: " << (DEFAULT_DISABLE_AUTH ? "true" : "false") << ")\n";
 		ss << "  --cache-max-mb <MB>      Max design cache size in MB before LRU eviction, 0 disables (default: " << DEFAULT_CACHE_MAX_MB << ")\n";
+		ss << "  --max-background-loads <N>  Max concurrent background design loads, 0 = unbounded (default: " << DEFAULT_MAX_BACKGROUND_LOADS << ")\n";
 		ss << "  --help                   Print this help message\n";
 		return ss.str();		
 	}	

--- a/OdbDesignLib/App/OdbDesignArgs.h
+++ b/OdbDesignLib/App/OdbDesignArgs.h
@@ -23,6 +23,7 @@ namespace Odb::Lib::App
 		bool loadAll() const;
 		bool disableAuthentication() const;
 		int cacheMaxMb() const;
+		int maxBackgroundLoads() const;
 
 	protected:
 		// Inherited via CommandLineArgs
@@ -40,6 +41,7 @@ namespace Odb::Lib::App
 		constexpr static const bool		DEFAULT_LOAD_ALL =		false;
 		constexpr static const bool		DEFAULT_DISABLE_AUTH = false;
 		constexpr static const int		DEFAULT_CACHE_MAX_MB = 4096;
+		constexpr static const int		DEFAULT_MAX_BACKGROUND_LOADS = 2;
 
 	};
 }

--- a/OdbDesignServer/Controllers/DesignsController.cpp
+++ b/OdbDesignServer/Controllers/DesignsController.cpp
@@ -3,8 +3,10 @@
 #include "UrlEncoding.h"
 #include "App/IOdbServerApp.h"
 #include "App/RouteController.h"
+#include "../Services/OdbDesignServiceImpl.h"
 #include <Logger.h>
 #include <cstring>
+#include <utility>
 #include <vector>
 
 
@@ -73,6 +75,20 @@ namespace Odb::App::Server
 					}
 
 					return this->design_route_handler(designName, req);
+				});
+
+		CROW_ROUTE(m_serverApp.crow_app(), "/designs/<string>/load")
+			.methods(crow::HTTPMethod::POST)
+			([&](const crow::request& req, std::string designName)
+				{
+					// authenticate request before sending to handler
+					auto authResp = m_serverApp.request_auth().AuthenticateRequest(req);
+					if (authResp.code != crow::status::OK)
+					{
+						return authResp;
+					}
+
+					return this->designs_load_route_handler(designName, req);
 				});
 
 		CROW_ROUTE(m_serverApp.crow_app(), "/designs/<string>/components")
@@ -218,6 +234,28 @@ namespace Odb::App::Server
 
 		return crow::response(JsonCrowReturnable(*pDesign));
 	}
+	crow::response DesignsController::designs_load_route_handler(std::string designName, const crow::request& req)
+	{
+		auto designNameDecoded = UrlEncoding::decode(designName);
+		if (designNameDecoded.empty())
+		{
+			return crow::response(crow::status::BAD_REQUEST, "design name not specified");
+		}
+
+		// Same pure status mapping as the gRPC RequestLoadDesign twin: never
+		// blocks on a parse, the only mutating call is the async-load kick.
+		const auto status = OdbDesignServer::Services::ComputeRequestLoadStatus(
+			m_serverApp.designs(), designNameDecoded);
+
+		crow::json::wvalue wv;
+		wv["designName"] = designNameDecoded;
+		wv["status"] = OdbDesignServer::Services::LoadStatusToString(status);
+
+		// 202 even for "not_found": the request itself succeeded, the body
+		// carries the load status distinction.
+		return crow::response(crow::status::ACCEPTED, std::move(wv));
+	}
+
 	crow::response DesignsController::designs_components_route_handler(std::string designName, const crow::request& req)
 	{
 		auto designNameDecoded = UrlEncoding::decode(designName);

--- a/OdbDesignServer/Controllers/DesignsController.h
+++ b/OdbDesignServer/Controllers/DesignsController.h
@@ -38,6 +38,10 @@ namespace Odb::App::Server
 		crow::response designs_list_route_handler(const crow::request& req);
 		crow::response design_route_handler(std::string designName, const crow::request& req);
 
+		// REST twin of the gRPC RequestLoadDesign RPC: kicks a background load
+		// (202 Accepted) and returns the load status in the body.
+		crow::response designs_load_route_handler(std::string designName, const crow::request& req);
+
 		crow::response designs_components_route_handler(std::string designName, const crow::request& req);
 		crow::response designs_component_route_handler(std::string designName, std::string refDes, const crow::request& req);
 

--- a/OdbDesignServer/Controllers/FileUploadController.cpp
+++ b/OdbDesignServer/Controllers/FileUploadController.cpp
@@ -11,6 +11,34 @@ using namespace std::filesystem;
 using namespace Odb::Lib::App;
 using namespace Utils;
 
+namespace
+{
+    // Fire-and-forget auto-warm: after an uploaded archive lands in the designs
+    // directory, kick a background parse (same path as RequestLoadDesign) so the
+    // first client request is warm. Never fails the upload response on a warm
+    // error; warm failures are logged only and stay retryable.
+    void autoWarmDesign(Odb::Lib::App::DesignCache& designs, const std::string& filename)
+    {
+        // Design names are archive file stems (matching DesignCache's scan)
+        const auto designName = path(filename).stem().string();
+        try
+        {
+            if (designs.LoadDesignAsync(designName))
+            {
+                CROW_LOG_INFO << "Auto-warm load kicked for uploaded design \"" << designName << "\"";
+            }
+            else
+            {
+                CROW_LOG_DEBUG << "Auto-warm for \"" << designName << "\" skipped: a load is already queued or in progress";
+            }
+        }
+        catch (const std::exception& e)
+        {
+            CROW_LOG_ERROR << "Auto-warm load failed to start for \"" << designName << "\": " << e.what();
+        }
+    }
+}
+
 namespace Odb::App::Server
 {
 	FileUploadController::FileUploadController(IOdbServerApp& serverApp)
@@ -123,6 +151,8 @@ namespace Odb::App::Server
             return crow::response(crow::status::INTERNAL_SERVER_ERROR, "failed handling new file");
         }
 
+        autoWarmDesign(m_serverApp.designs(), safeName);
+
         std::string responseBody = "{ \"filename\": \"" + safeName + "\" }";
 
         return makeLoadedFileModelsResponse(true);
@@ -203,6 +233,8 @@ namespace Odb::App::Server
             {
                 return crow::response(crow::status::INTERNAL_SERVER_ERROR, "failed handling new file");
             }
+
+            autoWarmDesign(m_serverApp.designs(), safeName);
 
             CROW_LOG_INFO << " Contents written to " << outfile_name << '\n';
         }

--- a/OdbDesignServer/Services/OdbDesignServiceImpl.cpp
+++ b/OdbDesignServer/Services/OdbDesignServiceImpl.cpp
@@ -628,6 +628,25 @@ namespace OdbDesignServer
             }
         }
 
+        grpc::Status OdbDesignServiceImpl::RequestLoadDesign(
+            grpc::ServerContext *context,
+            const Odb::Grpc::RequestLoadDesignRequest *request,
+            Odb::Grpc::RequestLoadDesignResponse *response)
+        {
+            try
+            {
+                loginfo("[ConnTrace] RequestLoadDesign: design_name=\"" + request->design_name() + "\"");
+                response->set_design_name(request->design_name());
+                response->set_status(ComputeRequestLoadStatus(*m_designCache, request->design_name()));
+                return grpc::Status::OK;
+            }
+            catch (const std::exception &e)
+            {
+                std::string error = "Internal server error: " + std::string(e.what());
+                return {grpc::StatusCode::INTERNAL, error};
+            }
+        }
+
         grpc::Status OdbDesignServiceImpl::HealthCheck(
             grpc::ServerContext *context,
             const Odb::Grpc::HealthCheckRequest *request,

--- a/OdbDesignServer/Services/OdbDesignServiceImpl.h
+++ b/OdbDesignServer/Services/OdbDesignServiceImpl.h
@@ -43,6 +43,10 @@ namespace OdbDesignServer {
                 const Odb::Grpc::GetStandardFontsRequest* request,
                 Odb::Lib::Protobuf::StandardFontsFile* response) override;
 
+            grpc::Status RequestLoadDesign(grpc::ServerContext* context,
+                const Odb::Grpc::RequestLoadDesignRequest* request,
+                Odb::Grpc::RequestLoadDesignResponse* response) override;
+
             grpc::Status HealthCheck(grpc::ServerContext* context,
                 const Odb::Grpc::HealthCheckRequest* request,
                 Odb::Grpc::HealthCheckResponse* response) override;
@@ -50,6 +54,48 @@ namespace OdbDesignServer {
             std::shared_ptr<Odb::Lib::App::DesignCache> m_designCache;
             std::shared_ptr<Config::GrpcServiceConfig> m_config;
         };
+
+        // Shared status mapping behind RequestLoadDesign (gRPC) and its REST twin
+        // (POST /designs/<name>/load). Pure lookup: never blocks on a parse; the
+        // only mutating call is the LoadDesignAsync kick, which returns
+        // immediately. Failed falls through to the kick path because a failed
+        // load is retryable by design.
+        inline Odb::Grpc::LoadStatus ComputeRequestLoadStatus(
+            Odb::Lib::App::DesignCache& designCache, const std::string& designName)
+        {
+            using Odb::Lib::App::DesignCache;
+
+            switch (designCache.GetLoadState(designName))
+            {
+            case DesignCache::LoadState::Loading:
+                return Odb::Grpc::LOAD_ALREADY_LOADING;
+            case DesignCache::LoadState::Loaded:
+                return Odb::Grpc::LOAD_ALREADY_LOADED;
+            default:
+                break;
+            }
+
+            if (!designCache.ContainsDesign(designName))
+            {
+                return Odb::Grpc::LOAD_NOT_FOUND;
+            }
+            return designCache.LoadDesignAsync(designName)
+                ? Odb::Grpc::LOAD_ACCEPTED
+                : Odb::Grpc::LOAD_ALREADY_LOADING;
+        }
+
+        // JSON status strings for the REST twin's response body
+        // ("accepted" | "already_loading" | "already_loaded" | "not_found").
+        // If/else rather than a switch: protobuf's synthetic
+        // _INT_MIN/MAX_SENTINEL_DO_NOT_USE_ enum values would trip -Wswitch.
+        inline const char* LoadStatusToString(Odb::Grpc::LoadStatus status)
+        {
+            if (status == Odb::Grpc::LOAD_ACCEPTED) return "accepted";
+            if (status == Odb::Grpc::LOAD_ALREADY_LOADING) return "already_loading";
+            if (status == Odb::Grpc::LOAD_ALREADY_LOADED) return "already_loaded";
+            if (status == Odb::Grpc::LOAD_NOT_FOUND) return "not_found";
+            return "unknown";
+        }
 
     } // namespace Services
 } // namespace OdbDesignServer

--- a/OdbDesignServer/protoc/grpc/service.proto
+++ b/OdbDesignServer/protoc/grpc/service.proto
@@ -33,6 +33,11 @@ service OdbDesignService {
   // as 3D stroke geometry.
   rpc GetStandardFonts(GetStandardFontsRequest) returns (.Odb.Lib.Protobuf.StandardFontsFile);
 
+  // Unary call to request a background load of a design archive.
+  // Returns immediately with the load status; it never blocks on the parse.
+  // A client can then poll GetDesign until the design is warm.
+  rpc RequestLoadDesign(RequestLoadDesignRequest) returns (RequestLoadDesignResponse);
+
   // A simple health check for the gRPC server
   rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
 }
@@ -71,6 +76,29 @@ message GetLayerSymbolsResponse {
 
 message GetStandardFontsRequest {
   string design_name = 1;
+}
+
+message RequestLoadDesignRequest {
+  string design_name = 1;
+}
+
+// Result of a RequestLoadDesign call. The request itself always succeeds;
+// the status distinguishes what was (or was not) kicked.
+message RequestLoadDesignResponse {
+  string design_name = 1;
+  LoadStatus status = 2;
+}
+
+// Lifecycle status of a requested background design load.
+enum LoadStatus {
+  // A fresh background load was kicked; the design will be warm once it completes.
+  LOAD_ACCEPTED = 0;
+  // A load for this design is already queued or parsing.
+  LOAD_ALREADY_LOADING = 1;
+  // The design is already loaded (warm); no load was kicked.
+  LOAD_ALREADY_LOADED = 2;
+  // No archive with this name exists in the designs directory; nothing was kicked.
+  LOAD_NOT_FOUND = 3;
 }
 
 message HealthCheckRequest {

--- a/OdbDesignTests/CMakeLists.txt
+++ b/OdbDesignTests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(OdbDesignTests
     "../OdbDesignServer/Services/OdbDesignServiceImpl.cpp"
     "GetStandardFontsTests.cpp"
     "GetLayerSymbolsTests.cpp"
+    "RequestLoadDesignTests.cpp"
 
     # NOTE: GrpcBatchStreamTests.cpp temporarily disabled due to CMake coupling concerns
     # Future: Will create separate test target for server component tests

--- a/OdbDesignTests/RequestLoadDesignTests.cpp
+++ b/OdbDesignTests/RequestLoadDesignTests.cpp
@@ -1,0 +1,416 @@
+#include <gtest/gtest.h>
+#include <grpcpp/server_context.h>
+
+#include "Fixtures/FileArchiveLoadFixture.h"
+#include "Fixtures/TestUtils.h"
+#include "OdbDesignServer/Services/OdbDesignServiceImpl.h"
+#include <App/DesignCache.h>
+#include <FileModel/Design/FileArchive.h>
+#include <chrono>
+#include <fstream>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+using namespace Odb::Lib::App;
+using namespace Odb::Test::Fixtures;
+using namespace Odb::Test::Utils;
+
+namespace Odb::Test
+{
+    namespace
+    {
+        // Counts DesignCache load-state transitions per design via the public
+        // AddLoadObserver API (same seam as DesignCacheSingleFlightTests). Shared
+        // with the observer lambda by shared_ptr so the callback can never dangle.
+        class LoadEventRecorder : public std::enable_shared_from_this<LoadEventRecorder>
+        {
+        public:
+            DesignCache::LoadEventCallback callback()
+            {
+                auto self = shared_from_this();
+                return [self](const std::string& name, DesignCache::LoadState from, DesignCache::LoadState to)
+                {
+                    (void)from;
+                    std::lock_guard<std::mutex> lock(self->m_mutex);
+                    if (to == DesignCache::LoadState::Loading) self->m_loadStarts[name]++;
+                    if (to == DesignCache::LoadState::Loaded) self->m_loadCompletions[name]++;
+                    if (to == DesignCache::LoadState::Failed) self->m_loadFailures[name]++;
+                    if (to == DesignCache::LoadState::Unloaded) self->m_revertedToUnloaded[name]++;
+                };
+            }
+
+            int loadStarts(const std::string& name)
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                return count(m_loadStarts, name);
+            }
+
+            int loadCompletions(const std::string& name)
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                return count(m_loadCompletions, name);
+            }
+
+            int loadFailures(const std::string& name)
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                return count(m_loadFailures, name);
+            }
+
+            int revertsToUnloaded(const std::string& name)
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                return count(m_revertedToUnloaded, name);
+            }
+
+        private:
+            static int count(const std::map<std::string, int>& counts, const std::string& name)
+            {
+                auto findIt = counts.find(name);
+                return findIt != counts.end() ? findIt->second : 0;
+            }
+
+            mutable std::mutex m_mutex;
+            std::map<std::string, int> m_loadStarts;
+            std::map<std::string, int> m_loadCompletions;
+            std::map<std::string, int> m_loadFailures;
+            std::map<std::string, int> m_revertedToUnloaded;
+        };
+
+        // Bounded poll for state/counters that change on background threads;
+        // predicate is re-checked after the timeout so a late flip still passes.
+        bool waitForCondition(std::function<bool()> predicate, std::chrono::milliseconds timeout)
+        {
+            const auto deadline = std::chrono::steady_clock::now() + timeout;
+            while (std::chrono::steady_clock::now() < deadline)
+            {
+                if (predicate())
+                {
+                    return true;
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            }
+            return predicate();
+        }
+
+        constexpr auto kParseTimeout = std::chrono::seconds(60);
+    }
+
+    // =========================================================================
+    // M1.2 tests: DesignCache::LoadDesignAsync (background load + semaphore)
+    // and the RequestLoadDesign gRPC handler (pure status mapping).
+    // =========================================================================
+    // Determinism note: same seam as DesignCacheSingleFlightTests — assertions
+    // count observer events (valid under any thread schedule); waits are bounded
+    // polls, and timing-sensitive mid-load assertions GTEST_SKIP when the parse
+    // finishes before they can be observed.
+    // =========================================================================
+    class RequestLoadDesignTest : public FileArchiveLoadFixture
+    {
+    protected:
+        void SetUp() override
+        {
+            if (getTestDataDir().empty())
+            {
+                GTEST_SKIP() << "Test data directory not available (ODB_TEST_DATA_DIR not set)";
+                return;
+            }
+            FileArchiveLoadFixture::SetUp();
+
+            m_sharedDesignCache = std::shared_ptr<DesignCache>(m_pDesignCache.release());
+            m_service = std::make_unique<OdbDesignServer::Services::OdbDesignServiceImpl>(m_sharedDesignCache);
+
+            m_recorder = std::make_shared<LoadEventRecorder>();
+            m_sharedDesignCache->AddLoadObserver(m_recorder->callback());
+        }
+
+        Odb::Grpc::RequestLoadDesignResponse requestLoad(const std::string& designName)
+        {
+            grpc::ServerContext ctx;
+            Odb::Grpc::RequestLoadDesignRequest req;
+            Odb::Grpc::RequestLoadDesignResponse resp;
+            req.set_design_name(designName);
+            m_lastStatus = m_service->RequestLoadDesign(&ctx, &req, &resp);
+            return resp;
+        }
+
+        std::shared_ptr<DesignCache> m_sharedDesignCache;
+        std::unique_ptr<OdbDesignServer::Services::OdbDesignServiceImpl> m_service;
+        std::shared_ptr<LoadEventRecorder> m_recorder;
+        grpc::Status m_lastStatus;
+    };
+
+    // ---- RequestLoadDesign handler: status mapping ----
+
+    TEST_F(RequestLoadDesignTest, ColdDesign_ReturnsAccepted_ThenLoadsInBackground)
+    {
+        const std::string designName = "designodb_rigidflex";
+
+        const auto resp = requestLoad(designName);
+        EXPECT_TRUE(m_lastStatus.ok()) << m_lastStatus.error_message();
+        EXPECT_EQ(resp.design_name(), designName);
+        EXPECT_EQ(resp.status(), Odb::Grpc::LOAD_ACCEPTED);
+
+        // The parse runs on the background thread; the state lands on Loaded
+        // through the same single-flight path as a synchronous load.
+        ASSERT_TRUE(waitForCondition([this, &designName]()
+        {
+            return m_sharedDesignCache->GetLoadState(designName) == DesignCache::LoadState::Loaded;
+        }, kParseTimeout)) << "design did not reach Loaded after an accepted background load";
+
+        EXPECT_EQ(m_recorder->loadStarts(designName), 1);
+        EXPECT_EQ(m_recorder->loadCompletions(designName), 1);
+
+        // A subsequent request is served from the cache without re-parsing
+        auto pDesign = m_sharedDesignCache->GetDesign(designName);
+        ASSERT_NE(pDesign, nullptr);
+        EXPECT_EQ(m_sharedDesignCache->GetLoadState(designName), DesignCache::LoadState::Loaded);
+        EXPECT_EQ(m_recorder->loadStarts(designName), 1) << "warm GetDesign after background load must not re-parse";
+
+        auto pFileArchive = m_sharedDesignCache->GetFileArchive(designName);
+        EXPECT_NE(pFileArchive, nullptr);
+    }
+
+    TEST_F(RequestLoadDesignTest, WarmDesign_ReturnsAlreadyLoaded)
+    {
+        const std::string designName = "sample_design";
+
+        auto pDesign = m_sharedDesignCache->GetDesign(designName);
+        ASSERT_NE(pDesign, nullptr);
+
+        const auto resp = requestLoad(designName);
+        EXPECT_TRUE(m_lastStatus.ok()) << m_lastStatus.error_message();
+        EXPECT_EQ(resp.design_name(), designName);
+        EXPECT_EQ(resp.status(), Odb::Grpc::LOAD_ALREADY_LOADED);
+
+        // No load was kicked for the warm design
+        EXPECT_EQ(m_recorder->loadStarts(designName), 1) << "RequestLoadDesign on a warm design must not re-parse";
+    }
+
+    TEST_F(RequestLoadDesignTest, UnknownDesign_ReturnsNotFound_AndKicksNoLoad)
+    {
+        const std::string missing = "no_such_design_anywhere";
+
+        const auto resp = requestLoad(missing);
+        EXPECT_TRUE(m_lastStatus.ok()) << m_lastStatus.error_message();
+        EXPECT_EQ(resp.design_name(), missing);
+        EXPECT_EQ(resp.status(), Odb::Grpc::LOAD_NOT_FOUND);
+
+        // The handler must resolve NOT_FOUND via ContainsDesign without
+        // triggering a load: no observer events, no state entry, name stays
+        // at the implicit Unloaded.
+        EXPECT_EQ(m_recorder->loadStarts(missing), 0);
+        EXPECT_EQ(m_sharedDesignCache->GetLoadState(missing), DesignCache::LoadState::Unloaded);
+    }
+
+    TEST_F(RequestLoadDesignTest, SecondCallDuringLoading_ReturnsAlreadyLoading)
+    {
+        const std::string designName = "designodb_rigidflex";  // slowest parse: widest Loading window
+
+        const auto first = requestLoad(designName);
+        EXPECT_EQ(first.status(), Odb::Grpc::LOAD_ACCEPTED);
+
+        const auto second = requestLoad(designName);
+        EXPECT_TRUE(m_lastStatus.ok());
+        if (second.status() == Odb::Grpc::LOAD_ALREADY_LOADED)
+        {
+            GTEST_SKIP() << "design parsed faster than the second request could arrive; "
+                            "already-loading path not exercised";
+        }
+        EXPECT_EQ(second.status(), Odb::Grpc::LOAD_ALREADY_LOADING);
+
+        ASSERT_TRUE(waitForCondition([this, &designName]()
+        {
+            return m_sharedDesignCache->GetLoadState(designName) == DesignCache::LoadState::Loaded;
+        }, kParseTimeout));
+
+        // The second request must not have started a second parse
+        EXPECT_EQ(m_recorder->loadStarts(designName), 1);
+    }
+
+    // ---- DesignCache::LoadDesignAsync ----
+
+    TEST_F(RequestLoadDesignTest, LoadDesignAsync_ObservesFullTransitionSet_AndCaches)
+    {
+        const std::string designName = "designodb_rigidflex";
+
+        EXPECT_TRUE(m_sharedDesignCache->LoadDesignAsync(designName));
+
+        ASSERT_TRUE(waitForCondition([this, &designName]()
+        {
+            return m_sharedDesignCache->GetLoadState(designName) == DesignCache::LoadState::Loaded;
+        }, kParseTimeout));
+
+        EXPECT_EQ(m_recorder->loadStarts(designName), 1);
+        EXPECT_EQ(m_recorder->loadCompletions(designName), 1);
+        EXPECT_EQ(m_recorder->loadFailures(designName), 0);
+
+        // Loaded result is cached: a warm read does not re-parse
+        auto pDesign = m_sharedDesignCache->GetDesign(designName);
+        ASSERT_NE(pDesign, nullptr);
+        EXPECT_EQ(m_recorder->loadStarts(designName), 1);
+    }
+
+    TEST_F(RequestLoadDesignTest, LoadDesignAsync_SecondKickDuringLoad_ReturnsFalse)
+    {
+        const std::string designName = "designodb_rigidflex";
+
+        EXPECT_TRUE(m_sharedDesignCache->LoadDesignAsync(designName));
+
+        // The pending-load marker is registered synchronously by the first
+        // kick, so a second kick during the load deterministically returns
+        // false regardless of how far the background parse has progressed.
+        EXPECT_FALSE(m_sharedDesignCache->LoadDesignAsync(designName));
+
+        ASSERT_TRUE(waitForCondition([this, &designName]()
+        {
+            return m_sharedDesignCache->GetLoadState(designName) == DesignCache::LoadState::Loaded;
+        }, kParseTimeout));
+
+        EXPECT_EQ(m_recorder->loadStarts(designName), 1) << "the second kick must not start a second parse";
+    }
+
+    TEST_F(RequestLoadDesignTest, LoadDesignAsync_FailedParse_FailedStateIsRetryable)
+    {
+        // Corrupt archive: garbage bytes that look like an archive by filename
+        auto tempDir = TestUtils::createManagedTempDirectory("requestload_broken");
+        const auto brokenPath = tempDir->path() / "broken.tgz";
+        {
+            std::ofstream out(brokenPath, std::ios::binary);
+            out << "this is not a valid archive";
+        }
+
+        DesignCache cache(tempDir->path().string());
+        auto recorder = std::make_shared<LoadEventRecorder>();
+        cache.AddLoadObserver(recorder->callback());
+
+        EXPECT_TRUE(cache.LoadDesignAsync("broken"));
+        ASSERT_TRUE(waitForCondition([&]()
+        {
+            return cache.GetLoadState("broken") == DesignCache::LoadState::Failed;
+        }, kParseTimeout));
+        EXPECT_EQ(recorder->loadFailures("broken"), 1);
+
+        // Failure must not poison the cache: a second kick retries the parse
+        EXPECT_TRUE(cache.LoadDesignAsync("broken"));
+        ASSERT_TRUE(waitForCondition([&]()
+        {
+            return recorder->loadFailures("broken") >= 2;
+        }, kParseTimeout));
+    }
+
+    TEST_F(RequestLoadDesignTest, LoadDesignAsync_MissingDesign_LoadRunsThenStaysUnloaded)
+    {
+        const std::string missing = "no_such_design_anywhere";
+
+        EXPECT_TRUE(m_sharedDesignCache->LoadDesignAsync(missing));
+
+        // The background load runs (single-flight start observed) and ends as a
+        // miss: the state entry is erased (Loading -> Unloaded revert), no
+        // Failed is recorded — identical to a synchronous miss.
+        ASSERT_TRUE(waitForCondition([this, &missing]()
+        {
+            return m_recorder->revertsToUnloaded(missing) == 1;
+        }, kParseTimeout));
+
+        EXPECT_EQ(m_sharedDesignCache->GetLoadState(missing), DesignCache::LoadState::Unloaded);
+        EXPECT_EQ(m_recorder->loadStarts(missing), 1);
+        EXPECT_EQ(m_recorder->loadFailures(missing), 0);
+    }
+
+    TEST_F(RequestLoadDesignTest, LoadDesignAsync_RespectsMaxBackgroundLoads)
+    {
+        const std::string slow = "designodb_rigidflex";   // holds the single slot
+        const std::string queued = "sample_design";
+
+        m_sharedDesignCache->setMaxBackgroundLoads(1);
+        EXPECT_EQ(m_sharedDesignCache->getMaxBackgroundLoads(), 1ull);
+
+        EXPECT_TRUE(m_sharedDesignCache->LoadDesignAsync(slow));
+
+        // Wait for the slow load to hold the slot (parse running). If it
+        // already completed, the semaphore path cannot be exercised.
+        const bool slowLoading = waitForCondition([this, &slow]()
+        {
+            return m_sharedDesignCache->GetLoadState(slow) == DesignCache::LoadState::Loading;
+        }, kParseTimeout);
+        if (!slowLoading)
+        {
+            GTEST_SKIP() << "design parsed faster than its Loading state could be observed; "
+                            "semaphore queueing path not exercised";
+        }
+
+        EXPECT_TRUE(m_sharedDesignCache->LoadDesignAsync(queued));
+
+        // The queued load must wait for the slot: it cannot have started
+        // parsing while the slow load holds the semaphore.
+        EXPECT_EQ(m_recorder->loadStarts(queued), 0)
+            << "queued background load started parsing while the semaphore was held";
+
+        // The queued load must not be announced as Loading either (its parse
+        // has not begun; the state is the implicit Unloaded).
+        EXPECT_EQ(m_sharedDesignCache->GetLoadState(queued), DesignCache::LoadState::Unloaded);
+
+        // Both complete once the slot frees up
+        ASSERT_TRUE(waitForCondition([this, &slow]()
+        {
+            return m_sharedDesignCache->GetLoadState(slow) == DesignCache::LoadState::Loaded;
+        }, kParseTimeout));
+        ASSERT_TRUE(waitForCondition([this, &queued]()
+        {
+            return m_sharedDesignCache->GetLoadState(queued) == DesignCache::LoadState::Loaded;
+        }, kParseTimeout));
+
+        EXPECT_EQ(m_recorder->loadStarts(slow), 1);
+        EXPECT_EQ(m_recorder->loadStarts(queued), 1);
+    }
+
+    // ---- --max-background-loads argument ----
+
+    TEST(RequestLoadDesignArgsTest, MaxBackgroundLoads_DefaultsTo2)
+    {
+        char arg0[] = "OdbDesignTests";
+        char* argv[] = { arg0 };
+        OdbDesignArgs args(1, argv);
+        EXPECT_EQ(args.maxBackgroundLoads(), 2);
+    }
+
+    TEST(RequestLoadDesignArgsTest, MaxBackgroundLoads_ParsesOverride)
+    {
+        char arg0[] = "OdbDesignTests";
+        char arg1[] = "--max-background-loads";
+        char arg2[] = "4";
+        char* argv[] = { arg0, arg1, arg2 };
+        OdbDesignArgs args(3, argv);
+        EXPECT_EQ(args.maxBackgroundLoads(), 4);
+    }
+
+    TEST(RequestLoadDesignArgsTest, MaxBackgroundLoads_ZeroMeansUnbounded)
+    {
+        char arg0[] = "OdbDesignTests";
+        char arg1[] = "--max-background-loads";
+        char arg2[] = "0";
+        char* argv[] = { arg0, arg1, arg2 };
+        OdbDesignArgs args(3, argv);
+        EXPECT_EQ(args.maxBackgroundLoads(), 0);
+
+        DesignCache cache(std::filesystem::temp_directory_path().string());
+        cache.setMaxBackgroundLoads(0);
+        EXPECT_EQ(cache.getMaxBackgroundLoads(), 0ull);
+    }
+
+    TEST(RequestLoadDesignArgsTest, MaxBackgroundLoads_InvalidValueFallsBackToDefault)
+    {
+        // A bare flag with no value stores the boolean `true`, which std::stoi
+        // would reject; the hardened getter must fall back to the default.
+        char arg0[] = "OdbDesignTests";
+        char arg1[] = "--max-background-loads";
+        char* argv[] = { arg0, arg1 };
+        OdbDesignArgs args(2, argv);
+        EXPECT_EQ(args.maxBackgroundLoads(), 2);
+    }
+}

--- a/swagger/odbdesign-server-0.9-swagger.yaml
+++ b/swagger/odbdesign-server-0.9-swagger.yaml
@@ -1061,6 +1061,37 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /designs/{name}/load:
+    post:
+      tags: [designs]
+      operationId: requestLoadDesign
+      summary: Request a background load of a design
+      description: |
+        Kicks a background parse of the design archive and returns immediately (the gRPC
+        twin is `OdbDesignService/RequestLoadDesign`). Never blocks on the parse: poll
+        `GET /designs/{name}` until the design is warm. Concurrent background parses are
+        capped (`--max-background-loads`, default 2); further requests queue. Designs
+        uploaded via `POST /files/upload*` are auto-warmed through the same path.
+      parameters:
+        - $ref: "#/components/parameters/DesignNameParam"
+      responses:
+        "202":
+          description: |
+            Load request processed. The body carries the resulting load status:
+            `accepted` (a background load was kicked), `already_loading`, `already_loaded`,
+            or `not_found` (no archive with that name on disk — reported in the body with
+            202, not as an HTTP 404, because the request itself succeeded).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RequestLoadDesignStatus"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   /healthz/live:
     get:
       tags: [health check]
@@ -1235,6 +1266,26 @@ components:
 
   schemas:
     # ------------------------------------------------------------------ common
+    RequestLoadDesignStatus:
+      type: object
+      description: |
+        Result of a load request (`POST /designs/{name}/load` and the gRPC
+        `RequestLoadDesign` twin). The request itself always succeeds; the status
+        distinguishes what was (or was not) kicked.
+      required: [designName, status]
+      properties:
+        designName:
+          type: string
+          description: Design (archive) name the request was made for.
+        status:
+          type: string
+          enum: [accepted, already_loading, already_loaded, not_found]
+          description: |
+            Lifecycle status of the requested background load: `accepted` — a
+            background load was kicked; `already_loading` — a load is already
+            queued or parsing; `already_loaded` — the design is warm, no load
+            was kicked; `not_found` — no archive with that name exists in the
+            designs directory, nothing was kicked.
     FileArchiveList:
       type: object
       description: Listing of design archives known to the server.


### PR DESCRIPTION
Milestone **M1.2** of [docs/plan/server-issues-implementation-plan.md](docs/plan/server-issues-implementation-plan.md) — SI7 `RequestLoadDesign(Async)`.

## What

- **gRPC**: unary `RequestLoadDesign(design_name) → {design_name, status}` with `LoadStatus` `LOAD_ACCEPTED | LOAD_ALREADY_LOADING | LOAD_ALREADY_LOADED | LOAD_NOT_FOUND`; returns instantly, never blocks on the parse.
- **`DesignCache::LoadDesignAsync`**: fire-and-forget background load riding the M1.1 single-flight machinery — identical state/observer transitions, `Clear()`-epoch abandonment, retryable failure semantics. A pending-marker set (checked under `m_loadStateMutex` before thread spawn) makes double-kick detection deterministic. Background parses are capped by a counting semaphore (`--max-background-loads`, default 2, 0 = unbounded — arg hardened like `--cache-max-mb`); `~DesignCache` drains detached loads on a condition variable so they can never outlive the cache.
- **`ContainsDesign`**: not-found distinguished from parse-failure without triggering a load (shared `FindArchivePath` stem-scan helper, permission-denied tolerant).
- **REST twin**: `POST /designs/{name}/load` → `202 Accepted` + `{"designName", "status"}` (`not_found` reported in-body; documented in the swagger spec). Status mapping is one inline helper shared by both channels — parity by construction.
- **Upload auto-warm**: both upload paths kick the background load after the archive lands (fire-and-forget; never fails the upload).
- `GetDesign`/`GetFileArchive` semantics unchanged (warm = immediate, cold = blocks — no longer the only path).

## Tests

13 new `RequestLoadDesignTests` (gRPC in-process pattern + `LoadDesignAsync` unit tests with observer recorder): ACCEPTED→warm polling, ALREADY_LOADED, NOT_FOUND, ALREADY_LOADING (skip-guarded), semaphore, failure retry. Suite **178/178**; new tests 3× re-run, zero flakes; `check-openapi-routes.py` green (41 code routes vs 39 spec paths + 2 allowlisted legacy).
