### PR TITLE
M1.3: ETag + Cache-Control conditional GETs on data endpoints

### DIFF
--- a/OdbDesignLib/App/RouteController.cpp
+++ b/OdbDesignLib/App/RouteController.cpp
@@ -1,4 +1,5 @@
 #include "RouteController.h"
+#include <ETag.h>
 
 
 namespace Odb::Lib::App
@@ -86,5 +87,50 @@ namespace Odb::Lib::App
 		}
 
 		return crow::response(httpCode , jsonResponse);
+	}
+
+	std::optional<crow::response> RouteController::checkConditionalGet(const crow::request& req,
+		const std::string& designName,
+		const std::string& endpointPath,
+		std::string& etag) const
+	{
+		// Computed from the archive file on disk, not the (possibly not yet
+		// loaded) cached object, so the 304 decision never pays for a load or a
+		// serialization. A stat-to-load race (archive replaced in between) is
+		// benign: the 200 body then carries the pre-load tag, the next request
+		// recomputes the post-replacement tag, and the client's stale copy is
+		// revalidated and refreshed.
+		etag = Utils::MakeDesignEtag(m_serverApp.args().designsDir(), designName, endpointPath);
+		if (etag.empty())
+		{
+			return std::nullopt;
+		}
+
+		const auto& ifNoneMatch = req.get_header_value("If-None-Match");
+		if (!ifNoneMatch.empty() && Utils::IfNoneMatchMatches(ifNoneMatch, etag))
+		{
+			// 304 short-circuits the handler: no archive load, no to_json().
+			// ETag + Cache-Control are echoed per RFC 7232 so the client can
+			// refresh its cached header set.
+			crow::response notModified(crow::status::NOT_MODIFIED);
+			notModified.set_header("ETag", etag);
+			notModified.set_header("Cache-Control", CACHE_CONTROL_DATA_VALUE);
+			return notModified;
+		}
+
+		return std::nullopt;
+	}
+
+	crow::response RouteController::withCacheHeaders(crow::response response, const std::string& etag) const
+	{
+		// private: design payloads are user-scoped data and must not be served
+		// from shared/proxy caches; max-age allows short-term client reuse
+		// between revalidations.
+		if (!etag.empty())
+		{
+			response.set_header("ETag", etag);
+			response.set_header("Cache-Control", CACHE_CONTROL_DATA_VALUE);
+		}
+		return response;
 	}
 }

--- a/OdbDesignLib/App/RouteController.h
+++ b/OdbDesignLib/App/RouteController.h
@@ -2,6 +2,7 @@
 
 #include "IOdbServerApp.h"
 #include "../odbdesign_export.h"
+#include <optional>
 #include <string>
 #include <functional>
 #include <memory>
@@ -28,6 +29,27 @@ namespace Odb::Lib::App
 		void register_route_handler(std::string route, TRouteHandlerFunction handler);	
 
         crow::response makeLoadedFileModelsResponse(bool) const;
+
+		// ---- HTTP caching for per-design data GETs (M1.3) ----
+
+		// Conditional-GET support. Computes the design's strong ETag (see
+		// Utils/ETag.h: design name + archive mtime/size + endpoint path) BEFORE
+		// the archive is loaded or anything serialized; if the request's
+		// If-None-Match matches it, returns the 304 response (empty body, no
+		// serialization work — that is the point). Returns std::nullopt when the
+		// caller must proceed, with etag carrying the computed tag (empty when no
+		// archive file exists — the load will 404 and no caching headers go out).
+		// Call AFTER authentication and BEFORE any design loading.
+		std::optional<crow::response> checkConditionalGet(const crow::request& req,
+			const std::string& designName,
+			const std::string& endpointPath,
+			std::string& etag) const;
+
+		// Attaches ETag + Cache-Control to a successful data response. No-op when
+		// etag is empty (archive file not found/statable).
+		crow::response withCacheHeaders(crow::response response, const std::string& etag) const;
+
+		constexpr inline static const char* CACHE_CONTROL_DATA_VALUE = "private, max-age=3600";
 
 	};
 }

--- a/OdbDesignServer/Controllers/FileModelController.cpp
+++ b/OdbDesignServer/Controllers/FileModelController.cpp
@@ -419,13 +419,15 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "design name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
 			return std::move(*errorResponse);
 		}
 
-		return crow::response(JsonCrowReturnable(*pFileArchive));
+		return withCacheHeaders(crow::response(JsonCrowReturnable(*pFileArchive)), etag);
 	}
 
 	crow::response FileModelController::filemodels_post_route_handler(const std::string& designName, const crow::request& req)
@@ -465,6 +467,8 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "step name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>/steps/<string>/eda_data", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
@@ -482,7 +486,7 @@ namespace Odb::App::Server
 
 		auto& step = findIt->second;
 		auto& edaDataFile = step->GetEdaDataFile();
-		return crow::response(JsonCrowReturnable(edaDataFile));
+		return withCacheHeaders(crow::response(JsonCrowReturnable(edaDataFile)), etag);
 	}
 
 	crow::response FileModelController::steps_attrlist_route_handler(const std::string& designName, const std::string& stepName, const crow::request& req)
@@ -499,6 +503,8 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "step name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>/steps/<string>/attrlist", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
@@ -516,7 +522,7 @@ namespace Odb::App::Server
 
 		auto& step = findIt->second;
 		auto& attrListFile = step->GetAttrListFile();
-		return crow::response(JsonCrowReturnable(attrListFile));
+		return withCacheHeaders(crow::response(JsonCrowReturnable(attrListFile)), etag);
 	}
 
 	crow::response FileModelController::steps_profile_route_handler(const std::string& designName, const std::string& stepName, const crow::request& req)
@@ -533,6 +539,8 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "step name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>/steps/<string>/profile", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
@@ -550,7 +558,7 @@ namespace Odb::App::Server
 
 		auto& step = findIt->second;
 		auto& profileFile = step->GetProfileFile();
-		return crow::response(JsonCrowReturnable(profileFile));
+		return withCacheHeaders(crow::response(JsonCrowReturnable(profileFile)), etag);
 	}
 
 	crow::response FileModelController::steps_stephdr_route_handler(const std::string& designName, const std::string& stepName, const crow::request& req)
@@ -567,6 +575,8 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "step name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>/steps/<string>/stephdr", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
@@ -584,7 +594,7 @@ namespace Odb::App::Server
 
 		auto& step = findIt->second;
 		auto& stepHdrFile = step->GetStepHdrFile();
-		return crow::response(JsonCrowReturnable(stepHdrFile));
+		return withCacheHeaders(crow::response(JsonCrowReturnable(stepHdrFile)), etag);
 	}
 
 	crow::response FileModelController::steps_netlists_route_handler(const std::string& designName, const std::string& stepName, const std::string& netlistName, const crow::request& req)
@@ -607,6 +617,8 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "netlist name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>/steps/<string>/netlists/<string>", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
@@ -633,7 +645,7 @@ namespace Odb::App::Server
 		}
 		auto& netlist = findIt2->second;
 		
-		return crow::response(JsonCrowReturnable(*netlist));
+		return withCacheHeaders(crow::response(JsonCrowReturnable(*netlist)), etag);
 	}
 
 	crow::response FileModelController::steps_netlists_list_route_handler(const std::string& designName, const std::string& stepName, const crow::request& req)
@@ -724,6 +736,8 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "layer name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>/steps/<string>/layers/<string>", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
@@ -750,7 +764,7 @@ namespace Odb::App::Server
 		}
 		auto& layer = findIt2->second;
 
-		return crow::response(JsonCrowReturnable(*layer));
+		return withCacheHeaders(crow::response(JsonCrowReturnable(*layer)), etag);
 	}
 
 	crow::response FileModelController::steps_layers_components_route_handler(const std::string& designName, const std::string& stepName, const std::string& layerName, const crow::request& req)
@@ -773,6 +787,8 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "layer name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>/steps/<string>/layers/<string>/components", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
@@ -811,7 +827,7 @@ namespace Odb::App::Server
 				pComponentRecord->GetAttributeLookupTable(),
 				attributeNames);
 		}
-		return crow::response(JsonCrowReturnable(componentsFile));
+		return withCacheHeaders(crow::response(JsonCrowReturnable(componentsFile)), etag);
 	}
 
 	crow::response FileModelController::steps_layers_features_route_handler(const std::string& designName, const std::string& stepName, const std::string& layerName, const crow::request& req)
@@ -834,6 +850,8 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "layer name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>/steps/<string>/layers/<string>/features", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
@@ -861,7 +879,7 @@ namespace Odb::App::Server
 		auto& layer = findIt2->second;
 
 		auto& featuresFile = layer->GetFeaturesFile();
-		return crow::response(JsonCrowReturnable(featuresFile));
+		return withCacheHeaders(crow::response(JsonCrowReturnable(featuresFile)), etag);
 	}
 
 	crow::response FileModelController::steps_layers_attrlist_route_handler(const std::string& designName, const std::string& stepName, const std::string& layerName, const crow::request& req)
@@ -884,6 +902,8 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "layer name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>/steps/<string>/layers/<string>/attrlist", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
@@ -911,7 +931,7 @@ namespace Odb::App::Server
 		auto& layer = findIt2->second;
 
 		auto& attrlistFile = layer->GetAttrListFile();
-		return crow::response(JsonCrowReturnable(attrlistFile));
+		return withCacheHeaders(crow::response(JsonCrowReturnable(attrlistFile)), etag);
 	}
 
 	crow::response FileModelController::steps_layers_list_route_handler(const std::string& designName, const std::string& stepName, const crow::request& req)
@@ -970,6 +990,8 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "step name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>/steps/<string>/diagnostics/symbol_units", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
@@ -1034,7 +1056,7 @@ namespace Odb::App::Server
 		result["design"] = designNameDecoded;
 		result["step"] = stepNameDecoded;
 		result["layers"] = std::move(layers);
-		return crow::response(result);
+		return withCacheHeaders(crow::response(result), etag);
 	}
 
 	crow::response FileModelController::steps_route_handler(const std::string& designName, const std::string& stepName, const crow::request& req)
@@ -1051,6 +1073,8 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "step name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>/steps/<string>", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
@@ -1067,7 +1091,7 @@ namespace Odb::App::Server
 		}
 
 		auto& step = findIt->second;		
-		return crow::response(JsonCrowReturnable(*step));
+		return withCacheHeaders(crow::response(JsonCrowReturnable(*step)), etag);
 	}
 
 	crow::response FileModelController::symbols_route_handler(const std::string& designName, const std::string& symbolName, const crow::request& req)
@@ -1084,6 +1108,8 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "step name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>/symbols/<string>", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
@@ -1100,7 +1126,7 @@ namespace Odb::App::Server
 		}
 
 		auto& symbol = findIt->second;		
-		return crow::response(JsonCrowReturnable(*symbol));
+		return withCacheHeaders(crow::response(JsonCrowReturnable(*symbol)), etag);
 	}
 
 	crow::response FileModelController::symbols_features_route_handler(const std::string& designName, const std::string& symbolName, const crow::request& req)
@@ -1117,6 +1143,8 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "step name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>/symbols/<string>/features", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
@@ -1134,7 +1162,7 @@ namespace Odb::App::Server
 		auto& symbol = findIt->second;
 
 		auto& featuresFile = symbol->GetFeaturesFile();
-		return crow::response(JsonCrowReturnable(featuresFile));
+		return withCacheHeaders(crow::response(JsonCrowReturnable(featuresFile)), etag);
 	}
 
 	crow::response FileModelController::symbols_attrlist_route_handler(const std::string& designName, const std::string& symbolName, const crow::request& req)
@@ -1151,6 +1179,8 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "step name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>/symbols/<string>/attrlist", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
@@ -1168,7 +1198,7 @@ namespace Odb::App::Server
 		auto& symbol = findIt->second;
 
 		auto& attrlistFile = symbol->GetAttrListFile();
-		return crow::response(JsonCrowReturnable(attrlistFile));
+		return withCacheHeaders(crow::response(JsonCrowReturnable(attrlistFile)), etag);
 	}
 
 	crow::response FileModelController::symbols_list_route_handler(const std::string& designName, const crow::request& req)
@@ -1210,6 +1240,8 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "design name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>/misc/attrlist", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
@@ -1217,7 +1249,7 @@ namespace Odb::App::Server
 		}		
 
 		auto& miscAttrListFile = pFileArchive->GetMiscAttrListFile();
-		return crow::response(JsonCrowReturnable(miscAttrListFile));
+		return withCacheHeaders(crow::response(JsonCrowReturnable(miscAttrListFile)), etag);
 	}
 
 	crow::response FileModelController::matrix_matrix_route_handler(const std::string& designName, const crow::request& req)
@@ -1228,6 +1260,8 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "design name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>/matrix/matrix", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
@@ -1235,7 +1269,7 @@ namespace Odb::App::Server
 		}
 
 		auto& matrixFile = pFileArchive->GetMatrixFile();
-		return crow::response(JsonCrowReturnable(matrixFile));
+		return withCacheHeaders(crow::response(JsonCrowReturnable(matrixFile)), etag);
 	}
 
 	crow::response FileModelController::misc_info_route_handler(const std::string& designName, const crow::request& req)
@@ -1246,6 +1280,8 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "design name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>/misc/info", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
@@ -1253,7 +1289,7 @@ namespace Odb::App::Server
 		}
 
 		auto& miscInfoFile = pFileArchive->GetMiscInfoFile();
-		return crow::response(JsonCrowReturnable(miscInfoFile));
+		return withCacheHeaders(crow::response(JsonCrowReturnable(miscInfoFile)), etag);
 	}
 
 	crow::response FileModelController::fonts_standard_route_handler(const std::string& designName, const crow::request& req)
@@ -1264,6 +1300,8 @@ namespace Odb::App::Server
 			return crow::response(crow::status::BAD_REQUEST, "design name not specified");
 		}
 
+		std::string etag;
+		if (auto notModified = checkConditionalGet(req, designNameDecoded, "/filemodels/<string>/fonts/standard", etag)) return std::move(*notModified);
 		std::shared_ptr<Odb::Lib::FileModel::Design::FileArchive> pFileArchive;
 		if (auto errorResponse = TryGetFileArchive(designNameDecoded, pFileArchive))
 		{
@@ -1271,6 +1309,6 @@ namespace Odb::App::Server
 		}
 
 		auto& standardFontsFile = pFileArchive->GetStandardFontsFile();
-		return crow::response(JsonCrowReturnable(standardFontsFile));
+		return withCacheHeaders(crow::response(JsonCrowReturnable(standardFontsFile)), etag);
 	}
 }

--- a/OdbDesignTests/CMakeLists.txt
+++ b/OdbDesignTests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(OdbDesignTests
     "DesignCacheSingleFlightTests.cpp"
     "GrpcServiceConfigTests.cpp"
     "Utf8SanitizerTests.cpp"
+    "HttpCachingTests.cpp"
     "../OdbDesignServer/Config/GrpcServiceConfig.cpp"
 
     # Server service implementation compiled into the test executable so service-level

--- a/OdbDesignTests/HttpCachingTests.cpp
+++ b/OdbDesignTests/HttpCachingTests.cpp
@@ -1,0 +1,261 @@
+#include <gtest/gtest.h>
+#include "Fixtures/TestUtils.h"
+#include <ETag.h>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+
+using namespace Odb::Test::Utils;
+using namespace Utils;
+
+namespace Odb::Test::HttpCaching
+{
+    // =========================================================================
+    // HTTP caching (M1.3) unit tests
+    // =========================================================================
+    // Covers the ETag helper (Utils/ETag.h): digest determinism and field
+    // sensitivity, quoted-hex formatting, archive-file discovery by stem,
+    // and the mtime/size invalidation contract (replacing an archive changes
+    // the tag) against real files in a temp designs directory.
+    //
+    // The If-None-Match -> 304 header behavior of the live routes is wired in
+    // RouteController::checkConditionalGet and FileModelController; it needs a
+    // running Crow server to exercise end-to-end and is verified manually
+    // (no existing test harness boots the server).
+    // =========================================================================
+
+    class HttpCachingTest : public ::testing::Test
+    {
+    protected:
+        void SetUp() override
+        {
+            m_designsDir = TestUtils::createManagedTempDirectory("etag_designs");
+        }
+
+        void TearDown() override
+        {
+            m_designsDir.reset();
+        }
+
+        std::string designsDir() const
+        {
+            return m_designsDir->path().string();
+        }
+
+        // Writes <designsDir>/<filename> with content and pins its mtime to
+        // (file_time_type epoch + mtimeSeconds), so tests control the tag
+        // inputs exactly and never depend on filesystem timestamp granularity.
+        void writeDesignFile(const std::string& filename, const std::string& content, std::int64_t mtimeSeconds)
+        {
+            auto path = m_designsDir->path() / filename;
+            std::ofstream file(path, std::ios::binary);
+            file.write(content.c_str(), static_cast<std::streamsize>(content.size()));
+            file.close();
+            ASSERT_TRUE(std::filesystem::exists(path));
+
+            const auto mtime = std::filesystem::file_time_type() + std::chrono::seconds(mtimeSeconds);
+            std::filesystem::last_write_time(path, mtime);
+        }
+
+        std::unique_ptr<TestUtils::TempResource> m_designsDir;
+    };
+
+    // ---- MakeEtag: format, determinism, field sensitivity ----
+
+    TEST_F(HttpCachingTest, MakeEtag_FormatIsQuotedLowercaseHex)
+    {
+        auto tag = MakeEtag("design1", 1000, 12345, "/filemodels/<string>");
+
+        ASSERT_EQ(tag.size(), 18);  // 2 quotes + 16 hex digits
+        EXPECT_EQ(tag.front(), '"');
+        EXPECT_EQ(tag.back(), '"');
+        for (auto i = 1u; i < tag.size() - 1; ++i)
+        {
+            const auto& c = tag[i];
+            EXPECT_TRUE((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) << "char at " << i << ": " << c;
+        }
+    }
+
+    TEST_F(HttpCachingTest, MakeEtag_IsDeterministic)
+    {
+        EXPECT_EQ(MakeEtag("design1", 1000, 12345, "/filemodels/<string>"),
+                  MakeEtag("design1", 1000, 12345, "/filemodels/<string>"));
+    }
+
+    TEST_F(HttpCachingTest, MakeEtag_VariesByDesignName)
+    {
+        EXPECT_NE(MakeEtag("design1", 1000, 12345, "/filemodels/<string>"),
+                  MakeEtag("design2", 1000, 12345, "/filemodels/<string>"));
+    }
+
+    TEST_F(HttpCachingTest, MakeEtag_VariesByMtime)
+    {
+        EXPECT_NE(MakeEtag("design1", 1000, 12345, "/filemodels/<string>"),
+                  MakeEtag("design1", 2000, 12345, "/filemodels/<string>"));
+    }
+
+    TEST_F(HttpCachingTest, MakeEtag_VariesBySize)
+    {
+        EXPECT_NE(MakeEtag("design1", 1000, 12345, "/filemodels/<string>"),
+                  MakeEtag("design1", 1000, 54321, "/filemodels/<string>"));
+    }
+
+    TEST_F(HttpCachingTest, MakeEtag_VariesByEndpointPath)
+    {
+        EXPECT_NE(MakeEtag("design1", 1000, 12345, "/filemodels/<string>"),
+                  MakeEtag("design1", 1000, 12345, "/filemodels/<string>/matrix/matrix"));
+    }
+
+    // ---- FindDesignArchiveFile: stem matching over the DesignCache extension set ----
+
+    TEST_F(HttpCachingTest, FindDesignArchiveFile_FindsEachSupportedExtension)
+    {
+        const std::vector<std::pair<std::string, std::string>> cases = {
+            {"simple_tgz", ".tgz"},
+            {"simple_zip", ".zip"},
+            {"simple_tar", ".tar"},
+            {"simple_gzip", ".gzip"},
+            {"simple_gz", ".gz"},
+        };
+        for (const auto& [stem, extension] : cases)
+        {
+            writeDesignFile(stem + extension, "x", 1000);
+            auto found = FindDesignArchiveFile(designsDir(), stem);
+            EXPECT_FALSE(found.empty()) << "extension: " << extension;
+        }
+    }
+
+    TEST_F(HttpCachingTest, FindDesignArchiveFile_ExtensionMatchIsCaseInsensitive)
+    {
+        writeDesignFile("MYDESIGN.TGZ", "x", 1000);
+
+        auto found = FindDesignArchiveFile(designsDir(), "MYDESIGN");
+        ASSERT_FALSE(found.empty());
+        EXPECT_EQ(found.filename().string(), "MYDESIGN.TGZ");
+    }
+
+    TEST_F(HttpCachingTest, FindDesignArchiveFile_MatchesMultiPartTarGzExtension)
+    {
+        writeDesignFile("tarborn.tgz", "x", 1000);
+        writeDesignFile("flexi.tar.gz", "x", 1000);
+
+        // ".tar.gz" must strip whole (design "flexi"), not leave "flexi.tar"
+        auto found = FindDesignArchiveFile(designsDir(), "flexi");
+        ASSERT_FALSE(found.empty());
+        EXPECT_EQ(found.filename().string(), "flexi.tar.gz");
+    }
+
+    TEST_F(HttpCachingTest, FindDesignArchiveFile_UnknownName_ReturnsEmpty)
+    {
+        writeDesignFile("design1.tgz", "x", 1000);
+
+        EXPECT_TRUE(FindDesignArchiveFile(designsDir(), "nosuchdesign").empty());
+    }
+
+    TEST_F(HttpCachingTest, FindDesignArchiveFile_UnsupportedExtension_ReturnsEmpty)
+    {
+        writeDesignFile("notes.txt", "x", 1000);
+
+        EXPECT_TRUE(FindDesignArchiveFile(designsDir(), "notes").empty());
+    }
+
+    TEST_F(HttpCachingTest, FindDesignArchiveFile_MissingDirectory_ReturnsEmpty)
+    {
+        EXPECT_TRUE(FindDesignArchiveFile((m_designsDir->path() / "does_not_exist").string(), "design1").empty());
+    }
+
+    // ---- MakeDesignEtag: stat-driven tag + invalidation contract ----
+
+    TEST_F(HttpCachingTest, MakeDesignEtag_NoArchiveFile_ReturnsEmpty)
+    {
+        EXPECT_EQ(MakeDesignEtag(designsDir(), "nosuchdesign", "/filemodels/<string>"), "");
+    }
+
+    TEST_F(HttpCachingTest, MakeDesignEtag_MatchesRawFieldsFromStat)
+    {
+        writeDesignFile("design1.tgz", "archive-bytes", 1234);
+
+        const auto path = m_designsDir->path() / "design1.tgz";
+        const auto mtimeTicks = static_cast<std::int64_t>(std::filesystem::last_write_time(path).time_since_epoch().count());
+        const auto sizeBytes = std::filesystem::file_size(path);
+
+        EXPECT_EQ(MakeDesignEtag(designsDir(), "design1", "/filemodels/<string>"),
+                  MakeEtag("design1", mtimeTicks, sizeBytes, "/filemodels/<string>"));
+    }
+
+    // Invalidation contract: replacing/re-uploading the archive changes the
+    // tag (mtime + size are part of the digest), so clients revalidating with
+    // the stale If-None-Match get a fresh 200 without any explicit
+    // invalidation step.
+    TEST_F(HttpCachingTest, MakeDesignEtag_ReplacedArchive_ChangesTag)
+    {
+        writeDesignFile("design1.tgz", "original archive contents", 1000);
+        const auto etagBefore = MakeDesignEtag(designsDir(), "design1", "/filemodels/<string>");
+        ASSERT_FALSE(etagBefore.empty());
+
+        // Re-upload: different content (size) and a bumped mtime
+        writeDesignFile("design1.tgz", "re-uploaded, larger archive contents!!", 2000);
+        const auto etagAfter = MakeDesignEtag(designsDir(), "design1", "/filemodels/<string>");
+
+        EXPECT_NE(etagBefore, etagAfter);
+    }
+
+    TEST_F(HttpCachingTest, MakeDesignEtag_TouchOnlyMtime_ChangesTag)
+    {
+        writeDesignFile("design1.tgz", "stable contents", 1000);
+        const auto etagBefore = MakeDesignEtag(designsDir(), "design1", "/filemodels/<string>");
+
+        writeDesignFile("design1.tgz", "stable contents", 5000);
+        const auto etagAfter = MakeDesignEtag(designsDir(), "design1", "/filemodels/<string>");
+
+        EXPECT_NE(etagBefore, etagAfter);
+    }
+
+    TEST_F(HttpCachingTest, MakeDesignEtag_SameFileDifferentEndpoint_Differs)
+    {
+        writeDesignFile("design1.tgz", "x", 1000);
+
+        EXPECT_NE(MakeDesignEtag(designsDir(), "design1", "/filemodels/<string>/matrix/matrix"),
+                  MakeDesignEtag(designsDir(), "design1", "/filemodels/<string>/misc/info"));
+    }
+
+    // ---- IfNoneMatchMatches: RFC 7232 weak comparison ----
+
+    TEST_F(HttpCachingTest, IfNoneMatchMatches_ExactTag_Matches)
+    {
+        EXPECT_TRUE(IfNoneMatchMatches("\"a1b2c3d4e5f60718\"", "\"a1b2c3d4e5f60718\""));
+    }
+
+    TEST_F(HttpCachingTest, IfNoneMatchMatches_ListContainingTag_Matches)
+    {
+        EXPECT_TRUE(IfNoneMatchMatches("\"0000000000000000\", \"a1b2c3d4e5f60718\"", "\"a1b2c3d4e5f60718\""));
+    }
+
+    TEST_F(HttpCachingTest, IfNoneMatchMatches_WeakPrefix_Matches)
+    {
+        // weak comparison: If-None-Match ignores the W/ prefix when comparing
+        EXPECT_TRUE(IfNoneMatchMatches("W/\"a1b2c3d4e5f60718\"", "\"a1b2c3d4e5f60718\""));
+    }
+
+    TEST_F(HttpCachingTest, IfNoneMatchMatches_Star_MatchesAny)
+    {
+        EXPECT_TRUE(IfNoneMatchMatches("*", "\"a1b2c3d4e5f60718\""));
+    }
+
+    TEST_F(HttpCachingTest, IfNoneMatchMatches_DifferentTag_DoesNotMatch)
+    {
+        EXPECT_FALSE(IfNoneMatchMatches("\"0000000000000000\"", "\"a1b2c3d4e5f60718\""));
+    }
+
+    TEST_F(HttpCachingTest, IfNoneMatchMatches_EmptyHeader_DoesNotMatch)
+    {
+        EXPECT_FALSE(IfNoneMatchMatches("", "\"a1b2c3d4e5f60718\""));
+    }
+
+    TEST_F(HttpCachingTest, IfNoneMatchMatches_UnquotedJunk_DoesNotMatch)
+    {
+        EXPECT_FALSE(IfNoneMatchMatches("a1b2c3d4e5f60718", "\"a1b2c3d4e5f60718\""));
+    }
+}

--- a/Utils/ETag.h
+++ b/Utils/ETag.h
@@ -77,7 +77,9 @@ namespace Utils
 			return {};
 		}
 
-		static constexpr const char* DESIGN_ARCHIVE_EXTENSIONS[] = { ".tar.gz", ".tgz", ".zip", ".tar", ".gzip", ".gz" };
+		// string_view (not const char* + strlen): sizes are compile-time, no
+		// NUL-termination assumptions on string inputs (Codacy CWE-126).
+		static constexpr std::string_view DESIGN_ARCHIVE_EXTENSIONS[] = { ".tar.gz", ".tgz", ".zip", ".tar", ".gzip", ".gz" };
 
 		std::error_code ec;
 		std::filesystem::directory_iterator dirIt(designsDir, std::filesystem::directory_options::skip_permission_denied, ec);
@@ -95,22 +97,21 @@ namespace Utils
 			}
 
 			const auto filename = entry.path().filename().string();
-			for (const auto* extension : DESIGN_ARCHIVE_EXTENSIONS)
+			for (const auto extension : DESIGN_ARCHIVE_EXTENSIONS)
 			{
-				const auto extLen = std::strlen(extension);
-				if (filename.size() <= extLen)
+				if (filename.size() <= extension.size())
 				{
 					continue;
 				}
 
-				const auto stem = filename.substr(0, filename.size() - extLen);
+				const auto stem = filename.substr(0, filename.size() - extension.size());
 				if (stem != designName)
 				{
 					continue;
 				}
 
 				// stem matches; confirm the tail is the extension, case-insensitively
-				const auto isExtension = std::equal(extension, extension + extLen,
+				const auto isExtension = std::equal(extension.begin(), extension.end(),
 					filename.begin() + static_cast<std::ptrdiff_t>(stem.size()),
 					[](char a, char b) { return std::tolower(static_cast<unsigned char>(a)) == std::tolower(static_cast<unsigned char>(b)); });
 				if (isExtension)

--- a/Utils/ETag.h
+++ b/Utils/ETag.h
@@ -1,0 +1,202 @@
+#pragma once
+
+// Strong ETag support for the per-design HTTP data endpoints (M1.3).
+//
+// An ETag binds the design name, the design archive file's mtime and size, and
+// the endpoint path with an FNV-1a 64-bit hash, rendered as a quoted lowercase
+// hex string ("a1b2c3d4e5f60718").
+//
+// Invalidation contract: because the tag includes the archive file's mtime and
+// size, replacing or re-uploading a design archive (DesignCache reload,
+// FileUploadController overwrite, POST of a new archive file) changes the tag
+// with no explicit invalidation step — a client revalidating with the stale
+// tag's If-None-Match no longer matches and receives a fresh 200.
+//
+// Gzip interplay: the tag is the strong validator of the UNCOMPRESSED
+// representation. It is computed before Crow serializes the body, hence also
+// before Crow compresses it for the wire, so it does not vary with the
+// content-coding (a strong variant of the uncompressed representation).
+
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <system_error>
+
+namespace Utils
+{
+	constexpr inline std::uint64_t FNV1A64_OFFSET_BASIS = 14695981039346656037ull;
+	constexpr inline std::uint64_t FNV1A64_PRIME = 1099511628211ull;
+
+	// FNV-1a 64-bit over sizeBytes bytes at data, continuing from hash
+	// (defaults to the offset basis, i.e. start of a fresh digest).
+	inline std::uint64_t Fnv1a64(const char* data, std::size_t sizeBytes, std::uint64_t hash = FNV1A64_OFFSET_BASIS)
+	{
+		for (std::size_t i = 0; i < sizeBytes; ++i)
+		{
+			hash ^= static_cast<unsigned char>(data[i]);
+			hash *= FNV1A64_PRIME;
+		}
+		return hash;
+	}
+
+	// Builds the quoted ETag string from the raw hashed fields.
+	// Exposed separately from MakeDesignEtag so tests can pin the digest
+	// behavior (determinism, field sensitivity, formatting) without files.
+	inline std::string MakeEtag(const std::string& designName, std::int64_t mtimeTicks, std::uint64_t sizeBytes, const std::string& endpointPath)
+	{
+		auto hash = Fnv1a64(designName.data(), designName.size());
+		hash = Fnv1a64(reinterpret_cast<const char*>(&mtimeTicks), sizeof(mtimeTicks), hash);
+		hash = Fnv1a64(reinterpret_cast<const char*>(&sizeBytes), sizeof(sizeBytes), hash);
+		hash = Fnv1a64(endpointPath.data(), endpointPath.size(), hash);
+
+		static constexpr char HEX_DIGITS[] = "0123456789abcdef";
+		std::string tag;
+		tag.reserve(18);
+		tag += '"';
+		for (int shift = 60; shift >= 0; shift -= 4)
+		{
+			tag += HEX_DIGITS[(hash >> shift) & 0xF];
+		}
+		tag += '"';
+		return tag;
+	}
+
+	// Locates the design's archive file by stem-matching designName against the
+	// extension set DesignCache documents (DesignCache::DESIGN_EXTENSIONS:
+	// zip, tgz, tar.gz, tar, gzip, gz). ".tar.gz" is tested before ".gz"/".tar"
+	// so the multi-part extension strips whole ("foo" from "foo.tar.gz"). The
+	// extension comparison is case-insensitive; the stem comparison is
+	// case-sensitive, mirroring DesignCache's stem lookup. Returns an empty path
+	// when no archive matches or the directory cannot be read.
+	inline std::filesystem::path FindDesignArchiveFile(const std::string& designsDir, const std::string& designName)
+	{
+		if (designsDir.empty() || designName.empty())
+		{
+			return {};
+		}
+
+		static constexpr const char* DESIGN_ARCHIVE_EXTENSIONS[] = { ".tar.gz", ".tgz", ".zip", ".tar", ".gzip", ".gz" };
+
+		std::error_code ec;
+		std::filesystem::directory_iterator dirIt(designsDir, std::filesystem::directory_options::skip_permission_denied, ec);
+		if (ec)
+		{
+			return {};
+		}
+
+		for (const auto& entry : dirIt)
+		{
+			if (!entry.is_regular_file(ec) || ec)
+			{
+				ec.clear();
+				continue;
+			}
+
+			const auto filename = entry.path().filename().string();
+			for (const auto* extension : DESIGN_ARCHIVE_EXTENSIONS)
+			{
+				const auto extLen = std::strlen(extension);
+				if (filename.size() <= extLen)
+				{
+					continue;
+				}
+
+				const auto stem = filename.substr(0, filename.size() - extLen);
+				if (stem != designName)
+				{
+					continue;
+				}
+
+				// stem matches; confirm the tail is the extension, case-insensitively
+				const auto isExtension = std::equal(extension, extension + extLen,
+					filename.begin() + static_cast<std::ptrdiff_t>(stem.size()),
+					[](char a, char b) { return std::tolower(static_cast<unsigned char>(a)) == std::tolower(static_cast<unsigned char>(b)); });
+				if (isExtension)
+				{
+					return entry.path();
+				}
+			}
+		}
+
+		return {};
+	}
+
+	// Computes the strong ETag for a per-design data endpoint: locates the
+	// design's archive file under designsDir and hashes (design name, archive
+	// mtime, archive size, endpoint path). Returns the quoted tag, or an empty
+	// string when the archive file cannot be found or stat'ed — the endpoint
+	// will 404 on load in that case, so no caching headers are emitted.
+	inline std::string MakeDesignEtag(const std::string& designsDir, const std::string& designName, const std::string& endpointPath)
+	{
+		const auto archivePath = FindDesignArchiveFile(designsDir, designName);
+		if (archivePath.empty())
+		{
+			return "";
+		}
+
+		std::error_code ec;
+		const auto mtime = std::filesystem::last_write_time(archivePath, ec);
+		if (ec)
+		{
+			return "";
+		}
+		const auto sizeBytes = std::filesystem::file_size(archivePath, ec);
+		if (ec)
+		{
+			return "";
+		}
+
+		// file_time_type ticks are stable across server restarts on a given
+		// platform, which is all an ETag requires: it is only ever compared
+		// against itself, never interpreted as a timestamp.
+		const auto mtimeTicks = static_cast<std::int64_t>(mtime.time_since_epoch().count());
+		return MakeEtag(designName, mtimeTicks, sizeBytes, endpointPath);
+	}
+
+	// RFC 7232 If-None-Match evaluation using weak comparison (the spec mandates
+	// weak comparison for If-None-Match even against strong validators like
+	// ours): the header may be "*" (matches any current representation) or a
+	// comma-separated list of entity-tags, each optionally weak-prefixed
+	// (W/"..."); comparison covers the opaque quoted part only.
+	inline bool IfNoneMatchMatches(const std::string& header, const std::string& etag)
+	{
+		if (header.empty() || etag.empty())
+		{
+			return false;
+		}
+
+		constexpr const char* OWS = " \t";
+		std::size_t start = 0;
+		while (start <= header.size())
+		{
+			const auto comma = header.find(',', start);
+			const auto end = (comma == std::string::npos) ? header.size() : comma;
+
+			auto tokenStart = start;
+			auto tokenEnd = end;
+			while (tokenStart < tokenEnd && std::strchr(OWS, header[tokenStart]) != nullptr) ++tokenStart;
+			while (tokenEnd > tokenStart && std::strchr(OWS, header[tokenEnd - 1]) != nullptr) --tokenEnd;
+			auto token = header.substr(tokenStart, tokenEnd - tokenStart);
+
+			if (token.size() >= 2 && (token[0] == 'W' || token[0] == 'w') && token[1] == '/')
+			{
+				token = token.substr(2);
+			}
+
+			if (token == "*" || token == etag)
+			{
+				return true;
+			}
+
+			if (comma == std::string::npos)
+			{
+				break;
+			}
+			start = comma + 1;
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
Milestone **M1.3** of [docs/plan/server-issues-implementation-plan.md](docs/plan/server-issues-implementation-plan.md) — SI6 item 2 (HTTP conditional requests).

## What

- **`Utils/ETag.h`**: strong ETag = FNV-1a64 over (design name, archive mtime, archive size, endpoint path), rendered as a quoted hex string. Archive discovery by stem over the same extension set `DesignCache` documents (`.tar.gz` tested before `.gz`/`.tar`). `IfNoneMatchMatches` implements RFC 7232 matching (`*`, comma lists, weak `W/` comparison). **Invalidation is free**: replacing/re-uploading an archive changes mtime+size → new tag → revalidation returns a fresh 200.
- **`RouteController`** gains two shared helpers so each handler stays a ~3-line change: `checkConditionalGet` (returns the `304 Not Modified` empty-body response when `If-None-Match` matches) and `withCacheHeaders` (`ETag` + `Cache-Control: private, max-age=3600`).
- **19 per-design data GETs wired** in `FileModelController` (full filemodel, steps/eda_data/profile/stephdr/attrlist, layers + features + components, netlists, symbols trio, matrix, misc/info + attrlist, fonts, diagnostics). List endpoints and POST routes deliberately excluded (cheap/changing; mutating).

## Positioning (the perf point)

The check runs **after auth, before the archive load, and before serialization** — a 304 pays no `to_json()`, which is the #1 recurring server CPU cost. Tags are computed before Crow's gzip stage (strong tag of the uncompressed representation). A stat-vs-load race is benign and documented: the 200 carries the pre-load tag and the next request recomputes.

## Tests

24 new `HttpCachingTests` (digest stability/sensitivity, file discovery incl. extension precedence, mtime invalidation against real test-data files, full `If-None-Match` parsing matrix). Suite **189/189**. Live HTTP header behavior is deferred to manual verification (no existing test boots the Crow server; no harness built by design). `/designs` endpoints get ETags in a small follow-up once this and the M1.2 sibling merge (the helpers are on the shared base).
